### PR TITLE
Mute trashed resources for non manager user

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,0 @@
-.DS_Store

--- a/backend/src/main/java/com/opendigitaleducation/explorer/folders/FolderExplorerDbSql.java
+++ b/backend/src/main/java/com/opendigitaleducation/explorer/folders/FolderExplorerDbSql.java
@@ -330,7 +330,7 @@ public class FolderExplorerDbSql {
                         final String application = row.getString("application");
                         final String ent_id = row.getString("ent_id");
                         final Optional<Integer> parentOpt = Optional.ofNullable(parentId);
-                        mapTrashed.folders.put(id, new FolderTrashResult(id, parentOpt, application, ExplorerConfig.FOLDER_TYPE, ent_id));
+                        mapTrashed.folders.put(id, new FolderTrashResult(id, parentOpt, application, ExplorerConfig.FOLDER_TYPE, ent_id, Collections.emptyList()));
                     }
                 }));
             }
@@ -543,17 +543,19 @@ public class FolderExplorerDbSql {
         public final Optional<String> application;
         public final Optional<String> resourceType;
         public final Optional<String> entId;
+        public final List<String> trashedBy;
 
-        public FolderTrashResult(Integer id, Optional<Integer> parentId, String application, String resourceType, String entId) {
-            this(id, parentId, Optional.ofNullable(application), Optional.ofNullable(resourceType), Optional.ofNullable(entId));
+        public FolderTrashResult(Integer id, Optional<Integer> parentId, String application, String resourceType, String entId, List<String> trashedBy) {
+            this(id, parentId, Optional.ofNullable(application), Optional.ofNullable(resourceType), Optional.ofNullable(entId), trashedBy);
         }
 
-        public FolderTrashResult(Integer id, Optional<Integer> parentId, Optional<String> application, Optional<String> resourceType, Optional<String> entId) {
+        public FolderTrashResult(Integer id, Optional<Integer> parentId, Optional<String> application, Optional<String> resourceType, Optional<String> entId, List<String> trashedBy) {
             this.id = id;
             this.parentId = parentId;
             this.application = application;
             this.resourceType = resourceType;
             this.entId = entId;
+            this.trashedBy = trashedBy;
         }
     }
 

--- a/backend/src/main/java/com/opendigitaleducation/explorer/folders/FolderExplorerDbSql.java
+++ b/backend/src/main/java/com/opendigitaleducation/explorer/folders/FolderExplorerDbSql.java
@@ -315,7 +315,7 @@ public class FolderExplorerDbSql {
             final FolderTrashResults mapTrashed = new FolderTrashResults();
             if(!resourceIds.isEmpty()){
                 final ResourceExplorerDbSql resSql = new ResourceExplorerDbSql(client);
-                futures.add(resSql.trash(transaction, resourceIds, trashed).onSuccess(resources->{
+                futures.add(resSql.trashForAll(transaction, resourceIds, trashed).onSuccess(resources->{
                     mapTrashed.resources.putAll(resources);
                 }));
             }

--- a/backend/src/main/java/com/opendigitaleducation/explorer/folders/ResourceExplorerDbSql.java
+++ b/backend/src/main/java/com/opendigitaleducation/explorer/folders/ResourceExplorerDbSql.java
@@ -445,7 +445,6 @@ public class ResourceExplorerDbSql {
         final String resource_type = row.getString("resource_type");
         final Boolean folder_trash = row.getBoolean("folder_trash");
         final Object shared = row.getJson("shared");
-        final Object mutedBy = row.getJson("muted_by");
         final long version = row.getLong("version");
         final Object rights = row.getJson("rights");
         final ResouceSql resource = getOrCreate.apply(new ResouceSql(entId, id, resourceUniqueId, creatorId, application, resource_type, version));
@@ -463,9 +462,6 @@ public class ResourceExplorerDbSql {
             if(shared instanceof JsonArray){
                 resource.shared.addAll((JsonArray) shared);
             }
-        }
-        if(mutedBy instanceof JsonObject) {
-            resource.mutedBy.mergeIn((JsonObject) mutedBy);
         }
         if(rights != null){
             if(rights instanceof JsonArray){
@@ -524,7 +520,7 @@ public class ResourceExplorerDbSql {
                 final String resource_type = row.getString("resource_type");
                 final String ent_id = row.getString("ent_id");
                 final Optional<Integer> parentOpt = Optional.empty();
-                mapTrashed.put(id, new FolderExplorerDbSql.FolderTrashResult(id, parentOpt, application, resource_type, ent_id));
+                mapTrashed.put(id, new FolderExplorerDbSql.FolderTrashResult(id, parentOpt, application, resource_type, ent_id, Collections.emptyList()));
             }
         });
         return future.map(mapTrashed);
@@ -552,7 +548,11 @@ public class ResourceExplorerDbSql {
                 final String resource_type = row.getString("resource_type");
                 final String ent_id = row.getString("ent_id");
                 final Optional<Integer> parentOpt = Optional.empty();
-                mapTrashed.put(id, new FolderExplorerDbSql.FolderTrashResult(id, parentOpt, application, resource_type, ent_id));
+                final List<String> trashedBy = ((JsonObject) row.getValue("trashed_by")).stream()
+                        .filter(trashers -> trashers.getValue().toString().equals("true"))
+                        .map(trashers -> trashers.getKey())
+                        .collect(Collectors.toList());
+                mapTrashed.put(id, new FolderExplorerDbSql.FolderTrashResult(id, parentOpt, application, resource_type, ent_id, trashedBy));
             }
         });
         return future.map(mapTrashed);

--- a/backend/src/main/java/com/opendigitaleducation/explorer/folders/ResourceExplorerDbSql.java
+++ b/backend/src/main/java/com/opendigitaleducation/explorer/folders/ResourceExplorerDbSql.java
@@ -498,6 +498,13 @@ public class ResourceExplorerDbSql {
             return  resources;
         });
     }
+
+    /**
+     * Trash resources for all users
+     * @param idsToTrashForEverybody ids of resources to be trashed for all users
+     * @param trashed whether a resource has to be trashed or restored
+     * @return resources info after trash status update
+     */
     public Future<Map<Integer, FolderExplorerDbSql.FolderTrashResult>> trashForAll(final Collection<Integer> idsToTrashForEverybody, final boolean trashed) {
         return client.transaction().compose(transaction->{
            final Future<Map<Integer, FolderExplorerDbSql.FolderTrashResult>> future = this.trashForAll(transaction, idsToTrashForEverybody, trashed);
@@ -526,6 +533,13 @@ public class ResourceExplorerDbSql {
         return future.map(mapTrashed);
     }
 
+    /**
+     * Trash resources for a specific user
+     * @param idsToTrashForUser ids of resources to be trashed for a specific user
+     * @param userId id of user trashing the resources
+     * @param trashed whether a resource has to be trashed or restored
+     * @return basic resources info after trash status update
+     */
     public Future<Map<Integer, FolderExplorerDbSql.FolderTrashResult>> trashForUser(final Collection<IdAndVersion> idsToTrashForUser, final String userId, final boolean trashed) {
         return client.transaction().compose(transaction->{
             final Future<Map<Integer, FolderExplorerDbSql.FolderTrashResult>> future = this.trashForUser(transaction, idsToTrashForUser, userId, trashed);

--- a/backend/src/main/java/com/opendigitaleducation/explorer/services/impl/ResourceServiceElastic.java
+++ b/backend/src/main/java/com/opendigitaleducation/explorer/services/impl/ResourceServiceElastic.java
@@ -193,8 +193,9 @@ public class ResourceServiceElastic implements ResourceService {
                 messagesToIngest.addAll(trashedForUserOnlyFuture.result().values().stream()
                         .filter(folderTrashResult -> folderTrashResult.application.isPresent() && folderTrashResult.resourceType.isPresent())
                         .map(folderTrashResult -> ExplorerMessage.upsert(new IdAndVersion(folderTrashResult.entId.get(), now), user, false, folderTrashResult.application.get(), folderTrashResult.resourceType.get(), folderTrashResult.resourceType.get())
-                                .withMute(user.getUserId(), isTrash)
-                                .withTrashedBy(user.getUserId(), isTrash))
+                                .withTrashedBy(folderTrashResult.trashedBy)
+                                .withVersion(now)
+                                .withSkipCheckVersion(true))
                         .collect(Collectors.toList()));
                 return communication.pushMessage(messagesToIngest);
             }).compose(a -> {

--- a/backend/src/main/resources/sql/006-trashed_by.sql
+++ b/backend/src/main/resources/sql/006-trashed_by.sql
@@ -1,0 +1,1 @@
+ALTER TABLE explorer.resources  ADD COLUMN trashed_by JSONB not null default '{}';

--- a/backend/src/main/resources/sql/007-clean-mute-and-trashed_by.sql
+++ b/backend/src/main/resources/sql/007-clean-mute-and-trashed_by.sql
@@ -1,0 +1,4 @@
+ALTER TABLE explorer.resources ALTER COLUMN muted_by DROP not null;
+ALTER TABLE explorer.resources ALTER COLUMN muted_by DROP default;
+ALTER TABLE explorer.resources ALTER COLUMN trashed_by DROP not null;
+ALTER TABLE explorer.resources ALTER COLUMN trashed_by DROP default;

--- a/backend/src/main/resources/sql/007-clean-mute-and-trashed_by.sql
+++ b/backend/src/main/resources/sql/007-clean-mute-and-trashed_by.sql
@@ -1,4 +1,0 @@
-ALTER TABLE explorer.resources ALTER COLUMN muted_by DROP not null;
-ALTER TABLE explorer.resources ALTER COLUMN muted_by DROP default;
-ALTER TABLE explorer.resources ALTER COLUMN trashed_by DROP not null;
-ALTER TABLE explorer.resources ALTER COLUMN trashed_by DROP default;

--- a/backend/src/test/resources/initExplorer.sql
+++ b/backend/src/test/resources/initExplorer.sql
@@ -74,7 +74,8 @@ CREATE TABLE explorer.resources (
     rights JSONB,
     version int,
     ingest_job_state VARCHAR(20),
-    muted_by JSONB not null default '{}',
+    muted_by JSONB,
+    trashed_by JSONB,
     PRIMARY KEY(id)
 );
 CREATE UNIQUE INDEX idx_resources_ent_id ON explorer.resources(resource_unique_id);

--- a/backend/src/test/resources/initExplorer.sql
+++ b/backend/src/test/resources/initExplorer.sql
@@ -74,8 +74,8 @@ CREATE TABLE explorer.resources (
     rights JSONB,
     version int,
     ingest_job_state VARCHAR(20),
-    muted_by JSONB,
-    trashed_by JSONB,
+    muted_by JSONB not null default '{}',
+    trashed_by JSONB not null default '{}',
     PRIMARY KEY(id)
 );
 CREATE UNIQUE INDEX idx_resources_ent_id ON explorer.resources(resource_unique_id);


### PR DESCRIPTION
This PR aims at dissociating mute & trashed status :
* Mute status : 
  * is represented by the **muted by** field for resources muted by specific users only
  * is stored only in PG database
* Trashed status :
  * is represented by : 
    * the **trashed** field for resources trashed for all users
    * the **trashed by** field for resources trashed by specific users only
  * is stored both in PG and Elastic Database
 
It offers the opportunity to mute a resources without trashing it.

Let's note that for resources trashed for all users, mute status is not updated (because globally trashed resources should not be updatable, so shouldn't generate notifications).

Also commit #4c13dd4 is brought by Nabil's strangely lost commit. Dunno why.

Finally, EUR documentation has been updated with details on trash, restore and mute API endpoints and with a scheme providing details about the workflow of a contributor trashing (and muting) a resource.