### PR TITLE
[ODE] corrections des filtres et requêtes autour du trashed_by

### DIFF
--- a/backend/src/main/java/com/opendigitaleducation/explorer/controllers/MuteController.java
+++ b/backend/src/main/java/com/opendigitaleducation/explorer/controllers/MuteController.java
@@ -45,17 +45,4 @@ public class MuteController extends BaseController {
         .onFailure(th -> renderError(request));
     }
 
-    // TODO what rights are allowed here
-    @Get("resources/:id/mutedBy")
-    @SecuredAction(value = "", type = ActionType.AUTHENTICATED)
-    public void getMutedBy(final HttpServerRequest request) {
-        getAuthenticatedUserInfos(eb, request)
-        .compose(userInfos -> {
-            final String id = request.getParam("id");
-            return muteService.getMutedBy(id, userInfos);
-        })
-        .onSuccess(e -> Renders.render(request, e))
-        .onFailure(th -> renderError(request));
-    }
-
 }

--- a/backend/src/main/java/com/opendigitaleducation/explorer/folders/ResourceExplorerDbSql.java
+++ b/backend/src/main/java/com/opendigitaleducation/explorer/folders/ResourceExplorerDbSql.java
@@ -300,7 +300,7 @@ public class ResourceExplorerDbSql {
         final String inPlaceholder = PostgresClient.inPlaceholder(ids, 1);
         final StringBuilder queryTpl = new StringBuilder();
         queryTpl.append("SELECT resources.id as resource_id,resources.ent_id,resources.resource_unique_id, ");
-        queryTpl.append("       resources.creator_id, resources.version, resources.application, resources.resource_type, resources.muted_by, resources.rights, ");
+        queryTpl.append("       resources.creator_id, resources.version, resources.application, resources.resource_type, resources.muted_by, resources.trashed_by, resources.rights, ");
         queryTpl.append("       f.id as folder_id, fr.user_id as user_id, f.trashed as folder_trash ");
         queryTpl.append("FROM explorer.resources  ");
         queryTpl.append("LEFT JOIN explorer.folder_resources fr ON resources.id=fr.resource_id ");
@@ -372,7 +372,7 @@ public class ResourceExplorerDbSql {
         queryTpl.append("   ON CONFLICT(resource_id, user_id) DO UPDATE SET folder_id=EXCLUDED.folder_id RETURNING * ");
         queryTpl.append(") ");
         queryTpl.append("SELECT upserted.id as resource_id,upserted.ent_id,upserted.resource_unique_id, ");
-        queryTpl.append("       upserted.creator_id, upserted.version, upserted.application, upserted.resource_type, upserted.muted_by, upserted.rights, ");
+        queryTpl.append("       upserted.creator_id, upserted.version, upserted.application, upserted.resource_type, upserted.muted_by,upserted.trashed_by, upserted.rights, ");
         queryTpl.append("       f.id as folder_id, updated.user_id as user_id, f.trashed as folder_trash ");
         queryTpl.append("FROM explorer.resources AS upserted ");
         queryTpl.append("INNER JOIN updated ON updated.resource_id=upserted.id ");

--- a/backend/src/main/java/com/opendigitaleducation/explorer/services/impl/ResourceQueryElastic.java
+++ b/backend/src/main/java/com/opendigitaleducation/explorer/services/impl/ResourceQueryElastic.java
@@ -234,12 +234,14 @@ public class ResourceQueryElastic {
         final JsonArray filter = new JsonArray();
         final JsonArray mustNot = new JsonArray();
         final JsonArray must = new JsonArray();
+        final JsonArray should = new JsonArray();
         payload.put("sort", sort);
         payload.put("query", query);
         query.put("bool", bool);
         bool.put("filter", filter);
         bool.put("must_not", mustNot);
         bool.put("must", must);
+        bool.put("should", should);
         //by creator
         final Optional<JsonObject> creatorIdTerm = createTerm("creatorId", creatorId);
         if (creatorIdTerm.isPresent()) {
@@ -307,7 +309,17 @@ public class ResourceQueryElastic {
             must.add(new JsonObject().put("multi_match", new JsonObject().put("query", text.get()).put("fields", fields)));
         }
         if (trashed.isPresent()) {
-            filter.add(new JsonObject().put("term", new JsonObject().put("trashed", trashed.get())));
+            if(trashed.get()){
+                should.add(new JsonObject().put("term", new JsonObject().put("trashed", true)));
+                if(this.user.isPresent()){
+                    should.add(new JsonObject().put("term", new JsonObject().put("trashedBy", this.user.get().getUserId())));
+                }
+            }else{
+                mustNot.add(new JsonObject().put("term", new JsonObject().put("trashed", true)));
+                if(this.user.isPresent()){
+                    mustNot.add(new JsonObject().put("term", new JsonObject().put("trashedBy", this.user.get().getUserId())));
+                }
+            }
         }
         if (pub.isPresent()) {
             filter.add(new JsonObject().put("term", new JsonObject().put("public", pub.get())));

--- a/backend/src/main/resources/es/mappingResource.json
+++ b/backend/src/main/resources/es/mappingResource.json
@@ -71,6 +71,9 @@
       "trashed": {
         "type": "boolean"
       },
+      "trashedBy": {
+        "type": "keyword"
+      },
       "favoriteFor": {
         "type": "keyword"
       },

--- a/backend/src/main/resources/jsonschema/getContext.json
+++ b/backend/src/main/resources/jsonschema/getContext.json
@@ -14,7 +14,6 @@
     "public": { "type": "boolean" },
     "favorite": { "type": "boolean" },
     "trashed": { "type": "boolean" },
-    "is_trash_view": { "type": "boolean" },
     "folder": {
       "anyOf": [
         {

--- a/frontend/src/services/queries/index.ts
+++ b/frontend/src/services/queries/index.ts
@@ -79,7 +79,7 @@ export const useSearchContext = () => {
     "context",
     {
       folderId: searchParams.filters.folder,
-      isTrashView: searchParams.isTrashView,
+      trashed: searchParams.trashed,
     },
   ];
 
@@ -142,7 +142,7 @@ export const useTrash = () => {
     "context",
     {
       folderId: searchParams.filters.folder,
-      isTrashView: searchParams.isTrashView,
+      trashed: searchParams.trashed,
     },
   ];
 
@@ -204,7 +204,7 @@ export const useRestore = () => {
     "context",
     {
       folderId: searchParams.filters.folder,
-      isTrashView: searchParams.isTrashView,
+      trashed: searchParams.trashed,
     },
   ];
 
@@ -263,7 +263,7 @@ export const useDelete = () => {
     "context",
     {
       folderId: searchParams.filters.folder,
-      isTrashView: searchParams.isTrashView,
+      trashed: searchParams.trashed,
     },
   ];
 
@@ -316,7 +316,7 @@ export const useMoveItem = () => {
     "context",
     {
       folderId: searchParams.filters.folder,
-      isTrashView: searchParams.isTrashView,
+      trashed: searchParams.trashed,
     },
   ];
 
@@ -366,7 +366,7 @@ export const useCreateFolder = () => {
     "context",
     {
       folderId: searchParams.filters.folder,
-      isTrashView: searchParams.isTrashView,
+      trashed: searchParams.trashed,
     },
   ];
 
@@ -418,7 +418,7 @@ export const useUpdatefolder = () => {
     "context",
     {
       folderId: searchParams.filters.folder,
-      isTrashView: searchParams.isTrashView,
+      trashed: searchParams.trashed,
     },
   ];
 
@@ -477,7 +477,7 @@ export const useShareResource = () => {
     "context",
     {
       folderId: searchParams.filters.folder,
-      isTrashView: searchParams.isTrashView,
+      trashed: searchParams.trashed,
     },
   ];
 
@@ -536,7 +536,7 @@ export const useUpdateResource = () => {
     "context",
     {
       folderId: searchParams.filters.folder,
-      isTrashView: searchParams.isTrashView,
+      trashed: searchParams.trashed,
     },
   ];
 

--- a/frontend/src/store/store.ts
+++ b/frontend/src/store/store.ts
@@ -91,7 +91,7 @@ export const useStoreContext = create<State>()((set, get) => ({
       pageSize: 48,
       maxIdx: 0,
     },
-    isTrashView: false,
+    trashed: false,
   },
   treeData: {
     id: FOLDER.DEFAULT,
@@ -190,7 +190,7 @@ export const useStoreContext = create<State>()((set, get) => ({
               ...searchParams.filters,
               folder: folderId,
             },
-            isTrashView: folderId === FOLDER.BIN,
+            trashed: folderId === FOLDER.BIN,
           },
         };
       });
@@ -206,7 +206,7 @@ export const useStoreContext = create<State>()((set, get) => ({
             "prefetchContext",
             {
               folderId,
-              isTrashView: false,
+              trashed: false,
             },
           ],
           queryFn: async () =>
@@ -222,7 +222,7 @@ export const useStoreContext = create<State>()((set, get) => ({
           "prefetchContext",
           {
             folderId,
-            isTrashView: false,
+            trashed: false,
           },
         ]);
         set((state) => ({
@@ -275,7 +275,7 @@ export const useStoreContext = create<State>()((set, get) => ({
           filters: {
             folder: FOLDER.BIN,
           },
-          isTrashView: true,
+          trashed: true,
         },
         currentFolder: {
           id: FOLDER.BIN,


### PR DESCRIPTION
### Description

Lors de l'introduction du trashed_by, un filtre java a été mis en place pour ne pas affiché les élements cachés par utilisateur dans la corbeille.
Le soucis avec ce filtre java c'est qu'il invalide la pagination géré côté elasticsearch.
Le fix a consisté à réutiliser le filtre historique (query params "trashed") et à prendre en compte: les fichiers "trashed" pour tout les utilisateurs + les fichiers trashed par utilisateur.

Au final on a 

- trashed=true => resource.trashed==true || resource.trashedBy[userid]==true (réaslisé grâce à l'opérateur should de ES)
- trashed=false => resource.trashed==false && resource.trashedBy[userid]==false (réaslisé grâce à mustNot de ES)

De plus en corrigeant cela je me suis rendu compte que l'introduction du trashed_by a cassé certains tests unitaires (notamment ResourceMoveTest). Du coup j'ai corrigé les requêtes qui pétaient les tests.

### Tests unitaires

- Ajout d'un test ResourceTrashTest
- Tout les autres tests passent bien à présent

### Ticket
WB2-788