### PR TITLE
feat: #WB2-644, enable apps to crud folders in explore

### DIFF
--- a/backend/src/main/java/com/opendigitaleducation/explorer/services/FolderService.java
+++ b/backend/src/main/java/com/opendigitaleducation/explorer/services/FolderService.java
@@ -13,6 +13,7 @@ public interface FolderService {
     default Future<JsonArray> fetch(final UserInfos creator, final String application, final Optional<String> parentId){
         return fetch(creator, Optional.ofNullable(application), parentId);
     }
+    void stopConsumer();
 
     Future<JsonArray> fetch(final UserInfos creator, final Optional<String> application, final Optional<String> parentId);
 

--- a/backend/src/main/java/com/opendigitaleducation/explorer/services/ResourceSearchOperation.java
+++ b/backend/src/main/java/com/opendigitaleducation/explorer/services/ResourceSearchOperation.java
@@ -25,6 +25,7 @@ public class ResourceSearchOperation {
     private Optional<String> id = Optional.empty();
     private Optional<String> rightType = Optional.empty();
     private Set<String> ids = new HashSet<>();
+    private Set<Long> folderIds = new HashSet<>();
     private Optional<String> searchAfter = Optional.empty();
     private boolean searchEverywhere = false;
     private boolean waitFor = false;
@@ -102,6 +103,10 @@ public class ResourceSearchOperation {
         this.favorite = Optional.ofNullable(favorite);
         return this;
     }
+    public ResourceSearchOperation setFolderIds(final Set<Long> parentIds) {
+        this.folderIds.addAll(parentIds);
+        return this;
+    }
 
     public Optional<Boolean> getPub() {return pub;}
 
@@ -129,6 +134,10 @@ public class ResourceSearchOperation {
             this.shared = Optional.ofNullable(shared);
         }
         return this;
+    }
+
+    public Set<Long> getFolderIds() {
+        return folderIds;
     }
 
     public ResourceSearchOperation setId(final String id) {

--- a/backend/src/main/java/com/opendigitaleducation/explorer/services/impl/ResourceQueryElastic.java
+++ b/backend/src/main/java/com/opendigitaleducation/explorer/services/impl/ResourceQueryElastic.java
@@ -8,6 +8,7 @@ import org.entcore.common.share.ShareRoles;
 import org.entcore.common.user.UserInfos;
 
 import java.util.*;
+import java.util.stream.Collectors;
 
 public class ResourceQueryElastic {
     private final Optional<UserInfos> user;
@@ -28,6 +29,7 @@ public class ResourceQueryElastic {
     private Optional<Boolean> pub = Optional.empty();
     private Optional<String> text = Optional.empty();
     private Optional<String> userRightType = Optional.empty();
+    private List<String> selectFields = new ArrayList<>();
 
     public ResourceQueryElastic(final UserInfos u) {
         this.user = Optional.ofNullable(u);
@@ -132,6 +134,11 @@ public class ResourceQueryElastic {
         return this;
     }
 
+    public ResourceQueryElastic withFolderIds(final Set<String> folderId) {
+        this.folderId.addAll(folderId);
+        return this;
+    }
+
     public ResourceQueryElastic withId(final String id) {
         this.id.add(id);
         return this;
@@ -139,6 +146,11 @@ public class ResourceQueryElastic {
 
     public ResourceQueryElastic withId(final Collection<String> id) {
         this.id.addAll(id);
+        return this;
+    }
+
+    public ResourceQueryElastic withLimitedFieldNames(final Collection<String> names) {
+        this.selectFields.addAll(names);
         return this;
     }
 
@@ -223,6 +235,9 @@ public class ResourceQueryElastic {
         if(operation.getRightType().isPresent()){
             this.userRightType = operation.getRightType();
         }
+        if(!operation.getFolderIds().isEmpty()){
+            this.folderId.addAll(operation.getFolderIds().stream().map(Object::toString).collect(Collectors.toSet()));
+        }
         return this;
     }
 
@@ -242,6 +257,10 @@ public class ResourceQueryElastic {
         bool.put("must_not", mustNot);
         bool.put("must", must);
         bool.put("should", should);
+        // select fields
+        if(!this.selectFields.isEmpty()){
+            payload.put("_source", new JsonArray(this.selectFields));
+        }
         //by creator
         final Optional<JsonObject> creatorIdTerm = createTerm("creatorId", creatorId);
         if (creatorIdTerm.isPresent()) {

--- a/backend/src/main/java/com/opendigitaleducation/explorer/services/impl/ResourceServiceElastic.java
+++ b/backend/src/main/java/com/opendigitaleducation/explorer/services/impl/ResourceServiceElastic.java
@@ -85,9 +85,10 @@ public class ResourceServiceElastic implements ResourceService {
         this.shareTableManager = shareTableManager;
         this.muteService = muteService;
         this.messageConsumer = communication.vertx().eventBus().consumer(ExplorerPlugin.RESOURCES_ADDRESS, message->{
-            final String action = message.headers().get("action");
+            final String actionName = message.headers().get("action");
+            final ExplorerPlugin.ResourceActions action = ExplorerPlugin.ResourceActions.valueOf(actionName);
             switch (action) {
-                case ExplorerPlugin.RESOURCES_GETSHARE:
+                case GetShares:
                     final JsonArray ids = (JsonArray)message.body();
                     final Set<String> idSet = ids.stream().map(e->e.toString()).collect(Collectors.toSet());
                     this.sql.getSharedByEntIds(idSet).onComplete(e->{

--- a/backend/src/test/java/com/opendigitaleducation/explorer/tests/ExplorerTestHelper.java
+++ b/backend/src/test/java/com/opendigitaleducation/explorer/tests/ExplorerTestHelper.java
@@ -111,6 +111,12 @@ public class ExplorerTestHelper implements TestRule {
         final Async async = context.async();
         createMapping(elasticClientManager, context, resourceIndex).compose(e -> {
             return createUpsertScript(context, "explorer-upsert-ressource", elasticClientManager);
+        }).compose(e->{
+            // create folder mapping
+            final String folderIndex = ExplorerConfig.DEFAULT_FOLDER_INDEX + "_" + System.currentTimeMillis();
+            ExplorerConfig.getInstance().setEsIndex(ExplorerConfig.FOLDER_APPLICATION, folderIndex);
+            final Buffer mapping = testHelper.vertx().fileSystem().readFileBlocking("es/mappingFolder.json");
+            return elasticClientManager.getClient().createMapping(folderIndex, mapping);
         }).onComplete(r -> async.complete());
     }
 


### PR DESCRIPTION
# Description

Ajout d'un MessageConsumer dans FolderService:
- il écoute les actions Upsert, List, Delete sur le bus
- List: récupère les dossiers de l'utilisateur appelant et les ressources rattachés aux dossiers
- Upsert: met à jour ou crée un dossier
- Delete: supprime un dossier définitivement

## Fixes

Ticket jira #WB2-644

## Type of change

Please check options that are relevant.

- [ ] Chore (PATCH)
- [ ] Doc (PATCH)
- [ ] Bug fix (PATCH)
- [X ] New feature (MINOR)


## Tests

Des TU sont dispo dans le module blog:
- Création d'arbo de dossiers
- Crud de dossiers
- Récupération de dossier par utilisateur
- Récupération des ressources rattachés aux dossiers

# Reminder

- Security flaws (bros before security holes)
- Performance impacts (think bulk !)
- Unit tests were replayed
- Unit tests were added and/or changed
- I have updated the reminder for the version including my modifications

- [ X] All done ! :smiley: