### PR TITLE
[ODE] Ne pas réécrire les droits de partages après la modification des propriétés d'une ressource

### DIFF
--- a/backend/src/main/java/com/opendigitaleducation/explorer/folders/ResourceExplorerDbSql.java
+++ b/backend/src/main/java/com/opendigitaleducation/explorer/folders/ResourceExplorerDbSql.java
@@ -138,8 +138,9 @@ public class ResourceExplorerDbSql {
             // TODO JBER check if this is not a problem when 2 share messages are executed in the same batch
             // because there is a single upsert per resource so if the messages are presented in a reverse chronological
             // order there could be some loss
-            if(e.getOptionalRights().isPresent()){
-                params.put("rights", e.getRights());
+            final JsonArray rights = e.getRights();
+            if(rights != null){
+                params.put("rights", rights);
             }
             return params;
         }).collect(Collectors.toList());


### PR DESCRIPTION
# Description

Lors de la modification des propriétés d'une resource, les droits de partages sont vidés parce que la valeur par défaut des droits est un tableau vide, qui est interprété par l'EUR comme le fait de vider les droits de partages. La valeur par défaut `[]` a donc été remplacé par un `null` qui a l'effet escompté (ne rien faire sur les partages quand on n'a pas d'informations à leur sujet).

## Fixes

WB2-996

## Type of change

Please check options that are relevant.

- [ ] Chore (PATCH)
- [ ] Doc (PATCH)
- [x] Bug fix (PATCH)
- [ ] New feature (MINOR)

## Tests

Le test du ticket

# Reminder

- Security flaws
- Performance impacts (think bulk !)
- Unit tests were replayed
- Unit tests were added and/or changed
- I have updated the reminder for the version including my modifications

- [x] All done ! :smiley: