### PR TITLE
Adding Create Resource Modal

### DIFF
--- a/frontend/src/features/Actionbar/components/EditResourceModal.tsx
+++ b/frontend/src/features/Actionbar/components/EditResourceModal.tsx
@@ -8,6 +8,7 @@ import {
   Modal,
 } from "@ode-react-ui/components";
 import { useOdeClient } from "@ode-react-ui/core";
+import { APP } from "ode-ts-client";
 import { createPortal } from "react-dom";
 import { useTranslation } from "react-i18next";
 
@@ -52,6 +53,7 @@ export default function EditResourceModal({
     onPublicChange,
   } = useEditResourceModal({
     resource,
+    edit,
     onSuccess,
     onCancel,
   });
@@ -128,20 +130,21 @@ export default function EditResourceModal({
             </div>
           </div>
 
-          {isActionAvailable({ workflow: "createPublic", actions }) && (
-            <BlogPublic
-              appCode={appCode}
-              correctSlug={correctSlug}
-              disableSlug={disableSlug}
-              onCopyToClipBoard={onCopyToClipBoard}
-              onPublicChange={onPublicChange}
-              onSlugChange={onSlugChange}
-              resource={resource}
-              slug={slug}
-              versionSlug={versionSlug}
-              register={register}
-            />
-          )}
+          {appCode === APP.BLOG &&
+            isActionAvailable({ workflow: "createPublic", actions }) && (
+              <BlogPublic
+                appCode={appCode}
+                correctSlug={correctSlug}
+                disableSlug={disableSlug}
+                onCopyToClipBoard={onCopyToClipBoard}
+                onPublicChange={onPublicChange}
+                onSlugChange={onSlugChange}
+                resource={resource}
+                slug={slug}
+                versionSlug={versionSlug}
+                register={register}
+              />
+            )}
         </form>
       </Modal.Body>
 

--- a/frontend/src/features/Actionbar/hooks/useEditResourceModal.tsx
+++ b/frontend/src/features/Actionbar/hooks/useEditResourceModal.tsx
@@ -3,7 +3,7 @@ import { useId, useState } from "react";
 import { Alert } from "@ode-react-ui/components";
 import { useOdeClient } from "@ode-react-ui/core";
 import { useHotToast } from "@ode-react-ui/hooks";
-import { type IResource } from "ode-ts-client";
+import { APP, type IResource } from "ode-ts-client";
 import { type SubmitHandler, useForm } from "react-hook-form";
 import { useTranslation } from "react-i18next";
 
@@ -132,7 +132,7 @@ export default function useEditResourceModal({
           <strong>{t("explorer.resource.updated")}</strong>
           <p>Titre: {formData.title}</p>
           <p>Description: {formData.description}</p>
-          {edit && (
+          {edit && appCode === APP.BLOG && (
             <p>
               Public:{" "}
               {formData.enablePublic

--- a/frontend/src/features/Explorer/components/AppAction/AppAction.tsx
+++ b/frontend/src/features/Explorer/components/AppAction/AppAction.tsx
@@ -1,25 +1,43 @@
-import { Button } from "@ode-react-ui/components";
+import { Suspense, lazy } from "react";
+
+import { Button, LoadingScreen } from "@ode-react-ui/components";
 import { useOdeClient } from "@ode-react-ui/core";
+import { useToggle } from "@ode-react-ui/hooks";
 import { Plus } from "@ode-react-ui/icons";
 import { useTranslation } from "react-i18next";
 
-import { useStoreActions } from "~/store";
+const CreateModal = lazy(
+  async () => await import("../../../Actionbar/components/EditResourceModal"),
+);
 
 export default function AppAction() {
+  const [isCreateResourceOpen, toggle] = useToggle();
   const { appCode } = useOdeClient();
   const { t } = useTranslation(appCode);
-  const { createResource } = useStoreActions();
 
   return (
-    <Button
-      type="button"
-      color="primary"
-      variant="filled"
-      leftIcon={<Plus />}
-      className="ms-auto"
-      onClick={createResource}
-    >
-      {t("explorer.create.title")}
-    </Button>
+    <>
+      <Button
+        type="button"
+        color="primary"
+        variant="filled"
+        leftIcon={<Plus />}
+        className="ms-auto"
+        onClick={toggle}
+      >
+        {t("explorer.create.title")}
+      </Button>
+
+      <Suspense fallback={<LoadingScreen />}>
+        {isCreateResourceOpen && (
+          <CreateModal
+            edit={false}
+            isOpen={isCreateResourceOpen}
+            onSuccess={toggle}
+            onCancel={toggle}
+          />
+        )}
+      </Suspense>
+    </>
   );
 }

--- a/frontend/src/services/api/index.ts
+++ b/frontend/src/services/api/index.ts
@@ -11,6 +11,7 @@ import {
   type UpdateParameters,
   type IFolder,
   type PublishParameters,
+  CreateParameters,
 } from "ode-ts-client";
 
 /**
@@ -234,11 +235,11 @@ export const goToResource = ({
 
 export const createResource = ({
   searchParams,
-  safeFolderId,
+  params,
 }: {
   searchParams: ISearchParameters;
-  safeFolderId: ID | undefined;
-}) => odeServices.resource(searchParams.app).gotoForm(safeFolderId);
+  params: CreateParameters;
+}) => odeServices.resource(searchParams.app).create(params);
 
 export const printResource = ({
   searchParams,

--- a/frontend/src/store/index.ts
+++ b/frontend/src/store/index.ts
@@ -59,7 +59,6 @@ interface State {
     clearSelectedItems: () => void;
     clearSelectedIds: () => void;
     openResource: (resource: IResource) => void;
-    createResource: () => void;
     printSelectedResource: () => void;
     publishApi: (
       type: ResourceType,
@@ -141,19 +140,6 @@ export const useStoreContext = create<State>()((set, get) => ({
         goToResource({ searchParams, assetId: resource.assetId });
       } catch (error) {
         console.error("explorer open failed: ", error);
-      }
-    },
-    createResource: () => {
-      try {
-        const { searchParams, currentFolder } = get();
-        const folderId = parseInt(currentFolder?.id || "default");
-        const safeFolderId = isNaN(folderId) ? undefined : folderId;
-        createResource({
-          searchParams,
-          safeFolderId: safeFolderId as string | undefined,
-        });
-      } catch (error) {
-        console.error("explorer create failed: ", error);
       }
     },
     printSelectedResource: () => {


### PR DESCRIPTION
https://edifice-community.atlassian.net/browse/WB2-67

Adding Create Resource Modal.

`CreateModal` is the same as `EditResourceModal`, the edit param is set to false. 
`CreateModal` is in `AppAction` Component where the Create Button is.

`CreateModal` shows a form with at least name, description and thumbnail fields.
The submit action calls a hook `useCreateResource` from `services/queries/index.ts` who calls the API Service from `ode-ts-client`. Each application has a specific `Service` and `create` method implementation in `ode-ts-client`.
**Blog and Mindmap have now the Create resource modal.** See https://github.com/opendigitaleducation/ode-ts-client/pull/1 for more information.

When the resource is created, the resource is added to existing resources via the `onSuccess` method of the `useCreateResource` hook