### PR TITLE
feat: #WB2-394, Crud stress test

### DIFF
--- a/backend/scripts/start.sh
+++ b/backend/scripts/start.sh
@@ -1,0 +1,12 @@
+#!/bin/bash
+
+set -e
+
+SCRIPT_DIR=$( cd -- "$( dirname -- "${BASH_SOURCE[0]}" )" &> /dev/null && pwd )
+
+k6 run -e BASE_URL=http://localhost:8090 \
+    -e USER_WEB_LOGIN=LOGIN \
+    -e USER_WEB_PWD=PASS \
+    -e BLOG_NUMBER=1000 \
+    -e SLEEP_SECONDS=2 \
+    $SCRIPT_DIR/../src/test/js/stresstest/scenarios/crud/index.js

--- a/backend/src/test/js/stresstest/scenarios/crud/index.js
+++ b/backend/src/test/js/stresstest/scenarios/crud/index.js
@@ -1,0 +1,253 @@
+import http from "k6/http";
+import exec from "k6/execution";
+import { check, group, sleep } from "k6";
+import chai, {
+  describe,
+  expect,
+} from "https://jslib.k6.io/k6chaijs/4.3.4.2/index.js";
+import {
+  authenticateWeb,
+  getConnectedUserId,
+  getHeaders,
+} from "../../utils/user.utils.js";
+import { BASE_URL } from "../../utils/env.utils.js";
+import { Session } from "../../utils/authentication.utils.js";
+/**
+ * Helper to log payload if http failed
+ * @param {*} response 
+ */
+export function logErrorPayload(response) {
+  if (!check(response, { "Status is 200": (r) => r.status === 200 })) {
+    console.log(response.status, response.body);
+  }
+}
+
+let USER_WEB_LOGIN = __ENV.USER_WEB_LOGIN;
+let USER_WEB_PWD = __ENV.USER_WEB_PWD;
+
+chai.config.logFailures = true;
+
+export let options = {
+  vus: 1,
+  iterations: 1,
+  thresholds: {
+    checks: ["rate > 0.95"],
+    // http_req_duration: ['p(95)<500'],
+    // error_rate: ['rate<0.1'],
+  },
+};
+const BLOG_NUMBER = __ENV.BLOG_NUMBER || 1;
+const SLEEP_SECONDS = __ENV.SLEEP_SECONDS || 1;
+console.log("Number of blog to create:", BLOG_NUMBER, "configured sleep seconds=", SLEEP_SECONDS)
+let webSession = new Session(null, null, -1);
+let webUserId;
+const suffix = new Date().getTime();
+function blogName(i) {
+  return `blog-${suffix + i}`;
+}
+/**
+ * GOAL: Ensure that CRUD operation works fine on explorer API when we have a lot of requests
+ * Steps:
+ * - Authenticate
+ * - Create X blogs having title "blog-${timestamp+i}"
+ * - Sleep ${SLEEP_SECONDS}s
+ * - Check if ${BLOG_NUMBER} blogs are fetchable through API Get /explorer/resources?id=
+ * - Update ${BLOG_NUMBER} blogs changing title to "blog-${timestamp+i}-updated"
+ * - Sleep ${SLEEP_SECONDS}s
+ * - Check if ${BLOG_NUMBER} blogs are fetchable through API Get /explorer/resources?id=
+ * - Check if ${BLOG_NUMBER} blogs have name changed to "blog-${timestamp+i}-updated"
+ * - Delete ${BLOG_NUMBER} blogs changing title to "blog-${timestamp+i}-updated"
+ * - Sleep ${SLEEP_SECONDS}s
+ * - Check if ${BLOG_NUMBER} blogs are not visible anymore through API Get /explorer/resources?id=
+ *
+ * We expect less than 5% errors
+ */
+export default function crudScenario() {
+  let blogs = {};
+  describe("[EXPLORER] crud blogs", () => {
+    group("[EXPLORER] should authenticate", () => {
+      if (webSession.isExpired()) {
+        webSession = authenticateWeb(USER_WEB_LOGIN, USER_WEB_PWD);
+      } else {
+        let jar = http.cookieJar();
+        jar.set(BASE_URL, "oneSessionId", webSession.token);
+        for (let cookie of webSession.cookies) {
+          jar.set(BASE_URL, cookie.name, cookie.value);
+        }
+      }
+      let session = webSession;
+      if (!webUserId) {
+        webUserId = getConnectedUserId(session);
+      }
+    });
+    group("[EXPLORER] should create blog", () => {
+      for (let i = 0; i < BLOG_NUMBER; i++) {
+        let title = blogName(i);
+        let session = webSession;
+        let headers = getHeaders(session);
+        let response = http.post(
+          `${BASE_URL}/blog`,
+          JSON.stringify({
+            title: title,
+            description: "<div><h1>MY BLOG</h1><p>MY CONTENT</p></div>",
+            visibility: "OWNER",
+            "comment-type": "IMMEDIATE",
+            "publish-type": "RESTRAINT",
+            slug: null,
+            thumbnail: "",
+          }),
+          { redirects: 0, headers }
+        );
+        logErrorPayload(response);
+        let checksOk = check(response, {
+          "check blog created": (r) => r.status == 200,
+          "check blog created without error": (r) => !r.json()["error"],
+        });
+        if (!checksOk) {
+          console.error("Could not create blog");
+          console.error(response);
+          exec.test.abort();
+        }
+      }
+    });
+    group("[EXPLORER] should read blog", () => {
+      sleep(SLEEP_SECONDS);
+      for (let i = 0; i < BLOG_NUMBER; i++) {
+        let title = blogName(i);
+        let session = webSession;
+        let headers = getHeaders(session);
+        let response = http.get(
+          `${BASE_URL}/explorer/resources?application=blog&resource_type=blog&search=${title}`,
+          { redirects: 0, headers }
+        );
+        logErrorPayload(response);
+        let checkOk = check(response, {
+          "check read blog": (r) => r.status == 200,
+          ["check blog visibility title=" + title]: (r) =>
+            r.json().resources.length > 0,
+        });
+        if (checkOk) {
+          blogs[title] = response.json().resources[0];
+        } else {
+          console.error("Could not read blog");
+          console.error(response);
+          exec.test.abort();
+        }
+      }
+    });
+    group("[EXPLORER] should update blog", () => {
+      for (let i = 0; i < BLOG_NUMBER; i++) {
+        let title = blogName(i);
+        let blog = blogs[title];
+        let session = webSession;
+        let headers = getHeaders(session);
+        let response = http.put(
+          `${BASE_URL}/blog/${blog.assetId}`,
+          JSON.stringify({
+            title: title + "-update",
+            description: "<div><h1>MY BLOG</h1><p>MY CONTENT</p></div>",
+            visibility: "OWNER",
+            "comment-type": "IMMEDIATE",
+            "publish-type": "RESTRAINT",
+            slug: null,
+            thumbnail: "",
+          }),
+          {
+            redirects: 0,
+            headers,
+          }
+        );
+        logErrorPayload(response);
+        let checkOk = check(response, {
+          "check update blog": (r) => r.status == 200,
+        });
+        if (!checkOk) {
+          console.error("Could not update blog");
+          console.error(response);
+          exec.test.abort();
+        }
+      }
+    });
+    group("[EXPLORER] should read updated blog", () => {
+      sleep(SLEEP_SECONDS);
+      for (let i = 0; i < BLOG_NUMBER; i++) {
+        let title = blogName(i);
+        let blog = blogs[title];
+        let session = webSession;
+        let headers = getHeaders(session);
+        let response = http.get(
+          `${BASE_URL}/explorer/resources?application=blog&resource_type=blog&owner=true&id=${blog.id}`,
+          "",
+          { redirects: 0, headers }
+        );
+        logErrorPayload(response);
+        let checkOk = check(response, {
+          "check read updated blog": (r) => r.status == 200,
+          ["check updated blog visibility id:" + blog.id]: (r) =>
+            r.json().resources.length > 0,
+          ["check updated blog name is updated id:" + blog.id]: (r) =>
+            r.json().resources[0].name === title + "-update",
+        });
+        if (checkOk) {
+          blog = response.json().resources[0];
+        } else {
+          console.error("Could not read after update blog");
+          console.error(response);
+          exec.test.abort();
+        }
+      }
+    });
+    group("[EXPLORER] should delete blog", () => {
+      for (let i = 0; i < BLOG_NUMBER; i++) {
+        let blog = blogs[blogName(i)];
+        let session = webSession;
+        let headers = getHeaders(session);
+        let response = http.del(
+          `${BASE_URL}/explorer`,
+          JSON.stringify({
+            application: "blog",
+            folderIds: [],
+            resourceIds: [blog.id],
+            resourceType: "blog",
+          }),
+          { redirects: 0, headers }
+        );
+        logErrorPayload(response);
+        let checkOk = check(response, {
+          "check deleted blog": (r) => r.status == 200,
+        });
+        if (!checkOk) {
+          console.error("Could not delete blog");
+          console.error(response);
+          exec.test.abort();
+        }
+      }
+    });
+    group("[EXPLORER] should not found deleted blog", () => {
+      sleep(SLEEP_SECONDS);
+      for (let i = 0; i < BLOG_NUMBER; i++) {
+        let blog = blogs[blogName(i)];
+        let session = webSession;
+        let headers = getHeaders(session);
+        let response = http.get(
+          `${BASE_URL}/explorer/resources?application=blog&resource_type=blog&owner=true&id=${blog.id}`,
+          "",
+          { redirects: 0, headers }
+        );
+        logErrorPayload(response);
+        let checkOk = check(response, {
+          "check delete blog": (r) => r.status == 200,
+          ["check deleted blog visibility id=" + blog.id]: (r) =>
+            r.json().resources.length == 0,
+        });
+        if (checkOk) {
+          blog = response.json().resources[0];
+        } else {
+          console.error("Could not fetch after deleted blog");
+          console.error(response);
+          exec.test.abort();
+        }
+      }
+    });
+  });
+}

--- a/backend/src/test/js/stresstest/utils/authentication.utils.js
+++ b/backend/src/test/js/stresstest/utils/authentication.utils.js
@@ -1,0 +1,18 @@
+export const SessionMode = {
+    COOKIE: 0,
+    OAUTH2: 1
+}
+export class Session {
+    constructor(token, mode, expiresIn, cookies) {
+        this.token = token;
+        this.mode = mode;
+        this.cookies = cookies;
+        this.expiresAt = Date.now() + (expiresIn * 1000) - 3000;
+    }
+    isExpired() {
+        return this.expiresAt <= Date.now();
+    }
+    getCookie(cookieName) {
+        return this.cookies ? this.cookies.filter(cookie => cookie.name === cookieName).map(cookie => cookie.value)[0] : null;
+    }
+}

--- a/backend/src/test/js/stresstest/utils/env.utils.js
+++ b/backend/src/test/js/stresstest/utils/env.utils.js
@@ -1,0 +1,1 @@
+export const BASE_URL = __ENV.BASE_URL;

--- a/backend/src/test/js/stresstest/utils/user.utils.js
+++ b/backend/src/test/js/stresstest/utils/user.utils.js
@@ -1,0 +1,77 @@
+import http from 'k6/http';
+import { check } from 'k6';
+import {BASE_URL} from './env.utils.js';
+import { Session, SessionMode } from './authentication.utils.js';
+
+const THIRTY_MINUTES_IN_SECONDS = 30 * 60;
+
+export const getHeaders = function(session) {
+  let headers;
+  if(session) {
+    if(session.mode === SessionMode.COOKIE) {
+       headers = {'x-xsrf-token': session.getCookie('XSRF-TOKEN')};
+    } else if(session.mode === SessionMode.OAUTH2) {
+      headers = {Authorization: `Bearer ${session.token}`};
+    } else {
+      headers = {};
+    }
+  } else {
+    headers = {};
+  }
+  return headers;
+}
+
+export const searchUser = function (q, session) {
+    const response = http.get(`${BASE_URL}/conversation/visible?search=${q}`, {headers: getHeaders(session)});
+    check(response, {
+      "should get an OK response": r => r.status == 200
+    });
+    return response.json('users')[0].id;
+}
+  
+export const getConnectedUserId = function (session) {
+    const response = http.get(`${BASE_URL}/auth/oauth2/userinfo`, {headers: getHeaders(session)});
+    check(response, {
+      "should get an OK response": r => r.status == 200,
+      "should get a valid userId": r => !!r.json('userId'),
+    });
+    return response.json('userId');
+}
+
+export const authenticateWeb = function(login, pwd) {
+  let credentials = {
+    'email': login,
+    'password': pwd,
+    'callBack': '',
+    'detail': ''
+  };
+
+  const response = http.post(`${BASE_URL}/auth/login`, credentials, { redirects: 0});
+  check(response, {
+    "should redirect connected user to login page": r => r.status === 302,
+    "should have set an auth cookie": r => r.cookies['oneSessionId'] !== null && r.cookies['oneSessionId'] !== undefined
+  });
+  const jar = http.cookieJar();
+  jar.set(BASE_URL, 'oneSessionId', response.cookies['oneSessionId'][0].value);
+  const cookies = Object.keys(response.cookies).map(cookieName => {return {name: cookieName, value: response.cookies[cookieName][0].value}});
+  return new Session(response.cookies['oneSessionId'][0].value, SessionMode.COOKIE, THIRTY_MINUTES_IN_SECONDS, cookies);
+}
+
+export const authenticateOAuth2 = function(login, pwd, clientId, clientSecret){
+  let credentials = {
+    'grant_type': 'password',
+    'username': login,
+    'password': pwd,
+    'client_id': clientId,
+    'client_secret': clientSecret,
+    'scope': 'timeline userbook blog lvs actualites pronote schoolbook support viescolaire zimbra conversation directory homeworks userinfo workspace portal cas sso presences incidents competences diary edt infra auth'
+  };
+
+  let response = http.post(`${BASE_URL}/auth/oauth2/token`, credentials, { redirects: 0});
+  check(response, {
+    "should get an OK response for authentication": r => r.status == 200,
+    "should have set an access token": r => !!r.json("access_token")
+  });
+  const accessToken = response.json("access_token");
+  return new Session(accessToken, SessionMode.OAUTH2, response.json("expires_in"));
+}


### PR DESCRIPTION
**Description**

Ticket : WB2-394 

Cette PR ajoute un stress test k6 qui effectue les opérations suivantes:
- Authenticate
- Création de X blogs qui ont pour titre "blog-${timestamp+i}"
- Sleep Y secondes pour laisser le temps d'ingérer les données
- Check si les blogs sont visible sur l'API Get /explorer/resources?id=
- Mise à jour des X blogs en changeant le titre en "blog-${timestamp+i}-updated"
- Sleep  Ys
- Check si les X blogs sont tjrs visibles API Get /explorer/resources?id=
- Check si les X blogs ont bien le nouveau titre"blog-${timestamp+i}-updated"
- Suppression des X blogs
- Sleep Y seconds
- Check si les X blogs sont bien "invisible" depuis l'API Get /explorer/resources?id=

X = une variable d'environnement ${BLOG_NUMBER} 
Y = une variable d'environnement ${SLEEP_SECONDS}s

Le scénario est un test avec 1 vue et 1 iterations. Chaque opération de CRUD faisant partie d'un groupe
J'ai mis arbitrairement un seuil d'erreur inférieur à 5%
J'ai eu 0% d'erreurs sur une PF de recette avec 1000 blogs et 2s de sleeps