### PR TITLE
fix: #WB2-1065, add right creator when create a resource

### DIFF
--- a/frontend/src/services/queries/index.ts
+++ b/frontend/src/services/queries/index.ts
@@ -735,7 +735,7 @@ export const useCreateResource = () => {
                   modifierName: data.author?.username || "",
                   updatedAt: Date.now() as unknown as string,
                   trashed: false,
-                  rights: [],
+                  rights: [`creator:${user?.userId}`],
                 };
 
                 return {


### PR DESCRIPTION
Ticket : WB2-1065

Description :

Ajout d'un tableau contenant le droit role créateur dans rights lors de la création d'une ressource. 