### PR TITLE
feat: #WB2-1025v2, forget to impliment textarea in PublishModal

### DIFF
--- a/frontend/src/features/Actionbar/components/EditResourceModal.tsx
+++ b/frontend/src/features/Actionbar/components/EditResourceModal.tsx
@@ -84,17 +84,19 @@ export default function EditResourceModal({
         </Heading>
 
         <form id={formId} onSubmit={handleSubmit(onSubmit)}>
-          <div className="d-flex flex-column flex-md-row gap-16 mb-24">
-            <ImagePicker
-              app={currentApp}
-              src={resource?.thumbnail}
-              label={t("explorer.imagepicker.label")}
-              addButtonLabel={t("explorer.imagepicker.button.add")}
-              deleteButtonLabel={t("explorer.imagepicker.button.delete")}
-              onUploadImage={handleUploadImage}
-              onDeleteImage={handleDeleteImage}
-              className="align-self-center"
-            />
+          <div className="d-flex gap-16 mb-24">
+            <div>
+              <ImagePicker
+                app={currentApp}
+                src={resource?.thumbnail}
+                label={t("explorer.imagepicker.label")}
+                addButtonLabel={t("explorer.imagepicker.button.add")}
+                deleteButtonLabel={t("explorer.imagepicker.button.delete")}
+                onUploadImage={handleUploadImage}
+                onDeleteImage={handleDeleteImage}
+                className="align-self-center mt-8"
+              />
+            </div>
 
             <div className="col">
               <FormControl id="title" className="mb-16" isRequired>

--- a/frontend/src/features/Actionbar/components/PublishModal.tsx
+++ b/frontend/src/features/Actionbar/components/PublishModal.tsx
@@ -13,6 +13,7 @@ import {
   SelectList,
   useOdeClient,
   usePaths,
+  TextArea,
 } from "@edifice-ui/react";
 import { type PublishResult } from "edifice-ts-client";
 import { createPortal } from "react-dom";
@@ -115,14 +116,12 @@ export default function PublishModal({
 
               <FormControl id="description" isRequired>
                 <Label>{t("bpr.form.publication.description")}</Label>
-                <Input
-                  type="text"
+                <TextArea
                   {...register("description", { required: true })}
                   placeholder={t(
                     "bpr.form.publication.description.placeholder",
                   )}
                   size="md"
-                  aria-required={true}
                 />
               </FormControl>
             </div>


### PR DESCRIPTION
Changements : 
Oubli d'intégrer le component `TextArea` dans la modal `PublishModal` + petites modifs pour fix l'image dans la modal `EditResourceModal` pour qu'elle ne se décale pas en fonction de la taille du `TextArea`

Ticket : #WB2-1025
https://edifice-community.atlassian.net/jira/software/c/projects/WB2/boards/41?modal=detail&selectedIssue=WB2-1025&assignee=712020%3A10bcae25-bc57-4d87-bad7-d00cf4320f32