### PR TITLE
[EDIFICE] #WB2-1176, Ne pas reset la resource principale lors de la mise à jour d'une sous ressource

### DIFF
--- a/backend/src/main/java/com/opendigitaleducation/explorer/ingest/MessageIngesterElasticOperation.java
+++ b/backend/src/main/java/com/opendigitaleducation/explorer/ingest/MessageIngesterElasticOperation.java
@@ -100,7 +100,9 @@ abstract class MessageIngesterElasticOperation {
             JsonObject changes = message.getMessage().copy();
             if(message.isSynthetic()) {
                 changes = keepOnlyOverride(changes);
-            } else {
+            } else if(message.getSubresources().size() == 0){
+                // when we have subresources we should not reset resource fields
+                //TODO decorrelate subresource and resources
                 changes = beforeCreate(changes);
             }
             this.version = message.getVersion();

--- a/backend/src/test/java/com/opendigitaleducation/explorer/IngestJobTest.java
+++ b/backend/src/test/java/com/opendigitaleducation/explorer/IngestJobTest.java
@@ -245,9 +245,9 @@ public abstract class IngestJobTest {
                             }));
                         }));
                     }));
-                    //user1 has 1 resource with text -> text2
-                    getResourceService().fetch(user1, application, new ResourceSearchOperation().setSearch("text2")).onComplete(context.asyncAssertSuccess(fetch1 -> {
-                        context.assertEquals(1, fetch1.size());
+                    //user1 has 2 resource with name starting with name2
+                    getResourceService().fetch(user1, application, new ResourceSearchOperation().setSearch("name2")).onComplete(context.asyncAssertSuccess(fetch1 -> {
+                        context.assertEquals(2, fetch1.size());
                         async.countDown();
                     }));
                 }));

--- a/backend/src/test/java/com/opendigitaleducation/explorer/ResourceServiceTest.java
+++ b/backend/src/test/java/com/opendigitaleducation/explorer/ResourceServiceTest.java
@@ -109,16 +109,16 @@ public class ResourceServiceTest {
     //TODO tester audience
     //TODO test pdf
     @Test
-    public void shouldSearchResourceWithHtml(TestContext context) {
+    public void shouldSearchResource(TestContext context) {
         final UserInfos user = test.directory().generateUser("userhtml");
         final JsonObject f1 = createHtml("html1", "name1", "<div><h1>MONHTML1</h1></div>", "content1", user);
         final JsonObject f2 = createHtml("html2", "name2", "<div><h1>MONHTML2</h1></div>", "content2", user);
-        final Async async = context.async(3);
+        final Async async = context.async(2);
         plugin.notifyUpsert(user, Arrays.asList(f1, f2)).onComplete(context.asyncAssertSuccess(r -> {
             job.execute(true).onComplete(context.asyncAssertSuccess(r4 -> {
                 resourceService.fetch(user, application, new ResourceSearchOperation()).onComplete(context.asyncAssertSuccess(fetch1 -> {
                     context.assertEquals(2, fetch1.size());
-                    resourceService.fetch(user, application, new ResourceSearchOperation().setSearch("MONHTML1")).onComplete(context.asyncAssertSuccess(fetch2 -> {
+                    resourceService.fetch(user, application, new ResourceSearchOperation().setSearch("name1")).onComplete(context.asyncAssertSuccess(fetch2 -> {
                         context.assertEquals(1, fetch2.size());
                         context.assertEquals("html1", fetch2.getJsonObject(0).getString("assetId"));
                         async.countDown();
@@ -128,55 +128,9 @@ public class ResourceServiceTest {
                         context.assertEquals("html2", fetch2.getJsonObject(0).getString("assetId"));
                         async.countDown();
                     }));
-                    resourceService.fetch(user, application, new ResourceSearchOperation().setSearch("content2")).onComplete(context.asyncAssertSuccess(fetch2 -> {
-                        context.assertEquals(1, fetch2.size());
-                        context.assertEquals("html2", fetch2.getJsonObject(0).getString("assetId"));
-                        async.countDown();
-                    }));
                 }));
             }));
         }));
-    }
-
-    @Test
-    public void shouldSearchResourceWithSubresources(TestContext context) {
-        final UserInfos user = test.directory().generateUser("usernested");
-        final ExplorerMessage f1 = ExplorerMessage.upsert(new IdAndVersion("id1", 1L), user, false, plugin.getApplication(), plugin.getResourceType(), plugin.getResourceType()).withCreator(user);
-        f1.withSubResourceContent("id1_1", "content1_1", ExplorerMessage.ExplorerContentType.Text).withSubResourceContent("id1_1", "<h1>html1_1</h1>", ExplorerMessage.ExplorerContentType.Html);
-        f1.withSubResourceContent("id1_2", "content1_2", ExplorerMessage.ExplorerContentType.Text).withSubResourceContent("id1_2", "<h1>html1_2</h1>", ExplorerMessage.ExplorerContentType.Html);
-        final ExplorerMessage f2 = ExplorerMessage.upsert(new IdAndVersion("id2", 1L), user, false, plugin.getApplication(), plugin.getResourceType(), plugin.getResourceType()).withCreator(user);
-        f2.withSubResourceContent("id2_1", "content2_1", ExplorerMessage.ExplorerContentType.Text).withSubResourceContent("id2_1", "<h1>html2_1</h1>", ExplorerMessage.ExplorerContentType.Html);
-        f2.withSubResourceContent("id2_2", "content2_2", ExplorerMessage.ExplorerContentType.Text).withSubResourceContent("id2_2", "<h1>html2_2</h1>", ExplorerMessage.ExplorerContentType.Html);
-        final Async async = context.async(3);
-        plugin.notifyUpsert(Arrays.asList(f1, f2)).onComplete(context.asyncAssertSuccess(r -> {
-            job.execute(true).onComplete(context.asyncAssertSuccess(r4 -> {
-                resourceService.fetch(user, application, new ResourceSearchOperation()).onComplete(context.asyncAssertSuccess(fetch1 -> {
-                    System.out.println(fetch1);
-                    context.assertEquals(2, fetch1.size());
-                    resourceService.fetch(user, application, new ResourceSearchOperation().setSearch("html1_1")).onComplete(context.asyncAssertSuccess(fetch2 -> {
-                        context.assertEquals(1, fetch2.size());
-                        context.assertEquals("id1", fetch2.getJsonObject(0).getString("assetId"));
-                        async.countDown();
-                    }));
-                    resourceService.fetch(user, application, new ResourceSearchOperation().setSearch("content2_1")).onComplete(context.asyncAssertSuccess(fetch2 -> {
-                        context.assertEquals(1, fetch2.size());
-                        context.assertEquals("id2", fetch2.getJsonObject(0).getString("assetId"));
-                        async.countDown();
-                    }));
-                    resourceService.fetch(user, application, new ResourceSearchOperation().setSearch("content2_2")).onComplete(context.asyncAssertSuccess(fetch2 -> {
-                        context.assertEquals(1, fetch2.size());
-                        context.assertEquals("id2", fetch2.getJsonObject(0).getString("assetId"));
-                        async.countDown();
-                    }));
-                }));
-            }));
-        }));
-
-    }
-
-    @Test
-    public void shouldSearchResourceWithComplexCriteria(TestContext context) {
-        //TODO
     }
 
 


### PR DESCRIPTION
# Description

Lorsqu'une sous ressource était modifié, les attributs principaux de la ressource (comme "public" par exemple était reset)
Ce fix évite ce reset lorsque le message d'upsert concerne une sous ressource
Les spec de recherche ayant un peu changé récemment il faudra à terme casser le lien ressource/subressource tel qu'il eixste actuellement. les sous ressources devraient avoir une existence propre. 

De plus ce commit fix/clean les tests unitaires suite au changement des spec de la recherche en autocomplete:
- plus de recherche full texte => prefix
- recherche uniquement dans le nom (plus dans la description ou le contenu)