### PR TITLE
[EDIFICE] Réindexation des ressources par leur état d'ingestion

### DIFF
--- a/backend/gradle.properties
+++ b/backend/gradle.properties
@@ -4,7 +4,7 @@ modowner=com.opendigitaleducation
 modname=explorer
 
 # Your module version
-version=1.3-develop-pedago-SNAPSHOT
+version=1.4-develop-pedago-SNAPSHOT
 
 # The test timeout in seconds
 testtimeout=300
@@ -28,6 +28,6 @@ vertxVersion=3.9.5
 toolsVersion=2.0.0-final
 junitVersion=4.10
 scramVersion=2.1
-entCoreVersion=4.11-develop-pedago-SNAPSHOT
+entCoreVersion=4.12-b2school-SNAPSHOT
 vertxCronTimer=2.0.0
 jsoupVersion=1.15.4

--- a/backend/src/main/java/com/opendigitaleducation/explorer/Explorer.java
+++ b/backend/src/main/java/com/opendigitaleducation/explorer/Explorer.java
@@ -54,11 +54,10 @@ import org.entcore.common.http.BaseServer;
 import org.entcore.common.postgres.IPostgresClient;
 
 import java.text.ParseException;
-import java.util.ArrayList;
-import java.util.List;
-import java.util.Optional;
-import java.util.Set;
+import java.util.*;
 import java.util.stream.Collectors;
+
+import static java.util.Collections.emptySet;
 
 public class Explorer extends BaseServer {
     static Logger log = LoggerFactory.getLogger(Explorer.class);
@@ -158,7 +157,7 @@ public class Explorer extends BaseServer {
                 final boolean dropBefore = migrateCron.getBoolean("drop-before-migrate", true);
                 final boolean migrateOldFolder = migrateCron.getBoolean("migrate-old-folder", true);
                 final boolean migrateNewFolder = migrateCron.getBoolean("migrate-new-folder", true);
-                new CronTrigger(vertx, cron).schedule(new MigrateCronTask(vertx, resourceService, apps, dropBefore, migrateOldFolder, migrateNewFolder));
+                new CronTrigger(vertx, cron).schedule(new MigrateCronTask(vertx, resourceService, apps, dropBefore, migrateOldFolder, migrateNewFolder, emptySet()));
             }else {
                 log.info("Migrate task is disabled");
             }

--- a/backend/src/main/java/com/opendigitaleducation/explorer/tasks/MigrateCronTask.java
+++ b/backend/src/main/java/com/opendigitaleducation/explorer/tasks/MigrateCronTask.java
@@ -47,15 +47,18 @@ public class MigrateCronTask implements Handler<Long> {
     private final ResourceService resourceService;
     private final Vertx vertx;
     private int migrationCounter = 0;
+    private final Set<String> states;
 
     public MigrateCronTask(final Vertx vertx, final ResourceService resourceService, final Set<String> applications,
-                           final boolean dropBefore, final boolean migrateOldFolder, final boolean migrateNewFolder) {
+                           final boolean dropBefore, final boolean migrateOldFolder, final boolean migrateNewFolder,
+                           final Set<String> states) {
         this.vertx = vertx;
         this.resourceService = resourceService;
         this.applications = applications;
         this.dropBefore = dropBefore;
         this.migrateOldFolder = migrateOldFolder;
         this.migrateNewFolder = migrateNewFolder;
+        this.states = states;
     }
 
     public Future<JsonArray> run(){
@@ -69,7 +72,7 @@ public class MigrateCronTask implements Handler<Long> {
             }) : Future.succeededFuture();
             final Future<IExplorerPluginClient.IndexResponse> future = dropFuture.compose(e -> {
                 final IExplorerPluginClient client = IExplorerPluginClient.withBus(vertx, application);
-                return client.reindex(null, new ExplorerReindexResourcesRequest(null, null, emptySet(), this.migrateOldFolder, emptySet()));
+                return client.reindex(null, new ExplorerReindexResourcesRequest(null, null, emptySet(), this.migrateOldFolder, emptySet(), this.states));
             });
             futures.add(future);
             future.onComplete(res -> {
@@ -89,7 +92,7 @@ public class MigrateCronTask implements Handler<Long> {
                 final IExplorerPluginClient client = IExplorerPluginClient.withBus(vertx, application);
                 return client.reindex(
                         null,
-                        new ExplorerReindexResourcesRequest(null, null, emptySet(), this.migrateOldFolder, emptySet())
+                        new ExplorerReindexResourcesRequest(null, null, emptySet(), this.migrateOldFolder, emptySet(), this.states)
                 );
             });
             futures.add(future);


### PR DESCRIPTION
# Description

Permettre de réindexer les ressources par leur état d'ingestion.
=> Ajout à la route d'indexation un paramètre GET `states` contenant la liste des états des ressources à réindexer.

## Fixes

wb-2243