### PR TITLE
[EDIFICE] Idempotence de la suppression de ressources

### DIFF
--- a/backend/src/main/java/com/opendigitaleducation/explorer/ingest/MessageIngesterElastic.java
+++ b/backend/src/main/java/com/opendigitaleducation/explorer/ingest/MessageIngesterElastic.java
@@ -42,7 +42,7 @@ public class MessageIngesterElastic implements MessageIngester {
     @Override
     public Future<IngestJob.IngestJobResult> ingest(final List<ExplorerMessageForIngest> messages) {
         if(messages.isEmpty()){
-            return Future.succeededFuture(new IngestJob.IngestJobResult(new ArrayList<>(), new ArrayList<>()));
+            return Future.succeededFuture(new IngestJob.IngestJobResult());
         }
         final List<MessageIngesterElasticOperation> operations = new ArrayList<>();
         final List<ExplorerMessageForIngest> failedTransformationToOperation = new ArrayList<>();
@@ -76,7 +76,7 @@ public class MessageIngesterElastic implements MessageIngester {
     }
 
     private Future<IngestJob.IngestJobResult> executeOperations(final List<MessageIngesterElasticOperation> operations) {
-        final IngestJob.IngestJobResult ingestJobResult = new IngestJob.IngestJobResult(new ArrayList<>(), new ArrayList<>());
+        final IngestJob.IngestJobResult ingestJobResult = new IngestJob.IngestJobResult();
         final ElasticBulkBuilder bulk = elasticClient.getClient().bulk(elasticOptions);
         for (MessageIngesterElasticOperation operation : operations) {
             operation.execute(bulk);

--- a/backend/src/main/java/com/opendigitaleducation/explorer/ingest/MessageReaderRedis.java
+++ b/backend/src/main/java/com/opendigitaleducation/explorer/ingest/MessageReaderRedis.java
@@ -230,7 +230,12 @@ public class MessageReaderRedis implements MessageReader {
         final List<Future> transactions = new ArrayList<>();
         //on succeed => ACK + DEL (DEL only if ACK succeed)
         //if we want transaction we cannot push all ids to ack or delete CMD at once
-        for (final ExplorerMessageForIngest mess : ingestResult.succeed) {
+        final List<ExplorerMessageForIngest> toAck = new ArrayList<>(ingestResult.succeed);
+        // We also acknowledge skipped messages because we know that
+        // they are not true failures and replaying them won't make
+        // them pass
+        toAck.addAll(ingestResult.skipped);
+        for (final ExplorerMessageForIngest mess : toAck) {
             if(mess.getIdQueue().isPresent()) {
                 final String idQueue = mess.getIdQueue().get();
                 final String stream = mess.getMetadata().getString(RedisClient.NAME_STREAM);


### PR DESCRIPTION
# Description

Lorsqu'un message de suppression de ressources est joué plusieurs fois ou lorsqu'un message de suppression de ressource cible une ressource qui n'a jamais été indexé, le job d'ingestion enregistrait cela comme un KO et faisait planter tout le batch.
Désormais, on ne fait que logguer un warning et on ne crée plus d'erreur.

## Type of change

Please check options that are relevant.

- [ ] Chore (PATCH)
- [ ] Doc (PATCH)
- [x] Bug fix (PATCH)
- [ ] New feature (MINOR)
- [ ] Breaking change (MAJOR)

## Tests réalisés :

(À faire avec `"stream": "postgres"` et `"stream": "redis"`)

1. Mettre `explorerConfig.enabled: false` dans la conf
2. Lancer l'ent
3. Créer un exercice
4. Mettre `explorerConfig.enabled: true `dans la conf
5. Mettre `"batch-size": 3` dans la conf
6. Créer 4 exercices
7. Vérifier qu'ils sont tous dans OS (sauf le tout premier) en allant là http://localhost:9200/resource-exercizer/_search
8. Sélectionner TOUS les sujets
9. Supprimer
10. Vérifier qu'il n'y a plus rien dans OS
11. Vérifier que dans les logs on a une trace menionnant qu'un message n'a pas pu être traité
12. Vérifier qu'il n'y a pas de messages définitivement perdus avec la commande `curl http://localhost:9090/metrics | grep too_much_attempts_total --color`
13. Vérifier dans les logs que l'on n'a pas de répétition à intervalle régulier de la trace  menionnant qu'un message n'a pas pu être traité

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings
