### PR TITLE
[EDIFICE] Réindexer les ressources ayant généré des messages supprimés du cycle d'ingestion

### DIFF
--- a/backend/README.md
+++ b/backend/README.md
@@ -2,6 +2,34 @@
 
 ## Installation
 
+### Containers
+
+Add this container to your springboard.
+
+```yaml
+  redis:
+    image: redis:5.0.3-alpine
+```
+
+### ENT conf
+
+Add this piece of configuration for module infra :
+
+```json
+{
+  "name": "org.entcore~infra~4.12-develop-pedago-SNAPSHOT",
+  ...
+  "config": {
+    ...
+    "explorerConfig": {
+      "enabled": true,
+      "postgres": false
+    }
+  }
+}
+```
+
+
 ### Build app
 
 ```sh
@@ -18,7 +46,6 @@ gradle clean install
 https://preprod-na.opendigitaleducation.com/explorer/reindex/exercizer/subject?include_folders=true&drop=true
 https://preprod-na.opendigitaleducation.com/explorer/reindex/blog/blog?include_folders=true&drop=true
 ```
-- Happy debugging sucker !
 
 ## Hacks 
 - Pour augmenter la taille de la file Mongo :

--- a/backend/deployment/conf.j2
+++ b/backend/deployment/conf.j2
@@ -33,7 +33,9 @@
             "max-attempt": 10,
             "batch-size": 100,
             "max-delay-ms": 2000,
-            "messageTransformers": [{"id": "htmlAnalyse", "minLength": 0}]
+            "messageTransformers": [{"id": "htmlAnalyse", "minLength": 0}],
+            "reindex-error-debounce-delay-ms": {{ explorerReindexErrorDebounceDelayMys | default(60000) }},
+            "reindex-error-debounce-queue-max-size": {{ explorerReindexErrorDebounceQueueMaxSize | default(-1) }}
         },
         "migrate-task":{
             "enabled": {{ explorerMigrateTaskEnabled | default('false') }},

--- a/backend/deployment/explorer/conf.json.template
+++ b/backend/deployment/explorer/conf.json.template
@@ -23,7 +23,9 @@
             "consumer-block-ms": 0,
             "max-attempt": 10,
             "batch-size": 100,
-            "max-delay-ms": 45000
+            "max-delay-ms": 45000,
+            "reindex-error-debounce-delay-ms": 60000,
+            "reindex-error-debounce-queue-max-size": -1
         },
         "migrate-task":{
             "enabled": false,

--- a/backend/src/main/java/com/opendigitaleducation/explorer/ingest/PermanentIngestionErrorHandler.java
+++ b/backend/src/main/java/com/opendigitaleducation/explorer/ingest/PermanentIngestionErrorHandler.java
@@ -1,0 +1,18 @@
+package com.opendigitaleducation.explorer.ingest;
+
+import io.vertx.core.Future;
+
+import java.util.List;
+
+/**
+ * Service that handles downstream treatments on failed messages.
+ */
+public interface PermanentIngestionErrorHandler {
+  /**
+   * Process the messages and complete the {@code Future} as soon as the treatment is done.
+   * @param permanentlyDeletedMessages Messages that have been played too many times and that will be evicted from the
+   *                                   ingestion job
+   * @return A completion signal
+   */
+  Future<Void> handleDeletedMessages(final List<ExplorerMessageForIngest> permanentlyDeletedMessages);
+}

--- a/backend/src/main/java/com/opendigitaleducation/explorer/ingest/impl/ChainPermanentIngestionErrorHandler.java
+++ b/backend/src/main/java/com/opendigitaleducation/explorer/ingest/impl/ChainPermanentIngestionErrorHandler.java
@@ -1,0 +1,46 @@
+package com.opendigitaleducation.explorer.ingest.impl;
+
+import com.opendigitaleducation.explorer.ingest.ExplorerMessageForIngest;
+import com.opendigitaleducation.explorer.ingest.PermanentIngestionErrorHandler;
+import io.vertx.core.Future;
+import io.vertx.core.Promise;
+
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.List;
+
+/**
+ * A chain of error handlers.
+ *
+ * <b><u>Notes :</u></b>
+ * <ul>
+ *   <li>The handlers will be called one after the other</li>
+ *   <li>If one handler fails it will not prevent the others from processing</li>
+ * </ul>
+ */
+public class ChainPermanentIngestionErrorHandler implements PermanentIngestionErrorHandler {
+  public final List<PermanentIngestionErrorHandler> chain;
+  public ChainPermanentIngestionErrorHandler(final PermanentIngestionErrorHandler... handlers) {
+    chain = new ArrayList<>();
+    if(handlers != null) {
+      chain.addAll(Arrays.asList(handlers));
+    }
+  }
+
+  @Override
+  public Future<Void> handleDeletedMessages(List<ExplorerMessageForIngest> permanentlyDeletedMessages) {
+    return handleChainLink(0, permanentlyDeletedMessages);
+  }
+
+  private Future<Void> handleChainLink(int idxChainLink, List<ExplorerMessageForIngest> permanentlyDeletedMessages) {
+    if(idxChainLink >= chain.size()) {
+      return Future.succeededFuture();
+    }
+    final Promise<Void> promise = Promise.promise();
+    final PermanentIngestionErrorHandler handler = chain.get(idxChainLink);
+    handler.handleDeletedMessages(permanentlyDeletedMessages)
+    .onComplete(e -> handleChainLink(idxChainLink + 1, permanentlyDeletedMessages)
+        .onComplete(onDone -> promise.complete()));
+    return promise.future();
+  }
+}

--- a/backend/src/main/java/com/opendigitaleducation/explorer/ingest/impl/DebouncedIngestionErrorReplayer.java
+++ b/backend/src/main/java/com/opendigitaleducation/explorer/ingest/impl/DebouncedIngestionErrorReplayer.java
@@ -1,0 +1,149 @@
+package com.opendigitaleducation.explorer.ingest.impl;
+
+import com.opendigitaleducation.explorer.ingest.ExplorerMessageForIngest;
+import com.opendigitaleducation.explorer.ingest.PermanentIngestionErrorHandler;
+import io.vertx.core.CompositeFuture;
+import io.vertx.core.Future;
+import io.vertx.core.Promise;
+import io.vertx.core.Vertx;
+import io.vertx.core.logging.Logger;
+import io.vertx.core.logging.LoggerFactory;
+import org.entcore.common.explorer.IExplorerPluginClient;
+import org.entcore.common.explorer.to.ExplorerReindexResourcesRequest;
+
+import java.util.*;
+import java.util.stream.Collectors;
+
+/**
+ * Accumulate error messages for a configurable maximum period of time and then call the client app to reindex the
+ * resources that generated the failures.
+ */
+public class DebouncedIngestionErrorReplayer implements PermanentIngestionErrorHandler {
+
+  public static final Logger log = LoggerFactory.getLogger(DebouncedIngestionErrorReplayer.class);
+  private final Map<MessageToSendKey, Set<String>> messagesToSend = new HashMap<>();
+  private final Vertx vertx;
+  /** The time (in milliseconds) that this service will wait before sending pending messages if no new messages have arrived.*/
+  private final long debounceDelay;
+  /** Maximum number of messages that can be held waiting. As soon as this limit is reached, the pending messages will be immediately sent.*/
+  private final int maxLength;
+  private Long taskId = null;
+
+  /**
+   *
+   * @param vertx Vertx instance
+   * @param debounceDelay The delay of inactivity before sending the waiting messages
+   * @param maxLength Maximum number of messages to stack before sending them
+   */
+  public DebouncedIngestionErrorReplayer(final Vertx vertx,
+                                         final long debounceDelay,
+                                         final int maxLength) {
+    this.vertx = vertx;
+    this.debounceDelay = debounceDelay;
+    this.maxLength = maxLength;
+  }
+
+  @Override
+  public Future<Void> handleDeletedMessages(final List<ExplorerMessageForIngest> permanentlyDeletedMessages) {
+    if(!permanentlyDeletedMessages.isEmpty()) {
+      final boolean hasChanged = addNewMessages(permanentlyDeletedMessages);
+      if(hasChanged) {
+        if (taskId != null) {
+          vertx.cancelTimer(taskId);
+        }
+        if(debounceDelay <= 0 || (maxLength > 0 && getSize() >= maxLength)) {
+          sendMessages();
+        } else {
+          taskId = vertx.setTimer(debounceDelay, l -> sendMessages());
+        }
+      }
+    }
+    return Future.succeededFuture();
+  }
+
+  private boolean addNewMessages(final List<ExplorerMessageForIngest> permanentlyDeletedMessages) {
+    boolean modified = false;
+    for (ExplorerMessageForIngest deletedMessage : permanentlyDeletedMessages) {
+      final String application = deletedMessage.getApplication();
+      final String type = deletedMessage.getResourceType();
+      final MessageToSendKey key = new MessageToSendKey(application, type);
+      final Set<String> messages = messagesToSend.computeIfAbsent(key, k -> new HashSet<>());
+      final String parentId = deletedMessage.getId();
+      if(!messages.contains(parentId)) {
+        messages.add(parentId);
+        modified = true;
+      }
+    }
+    return modified;
+  }
+
+  /**
+   * Immediately send pending messages.
+   * @return A Future that completes when the cache of messages to send have been cleared.
+   */
+  public Future<Void> sendMessages() {
+    final Future<Void> completion;
+    if(messagesToSend.isEmpty()) {
+      log.debug("[DebouncedIngestionErrorReplayer@sendMessages] Nothing to send");
+      completion = Future.succeededFuture();
+    } else {
+      log.info("[DebouncedIngestionErrorReplayer@sendMessages] Sending messages");
+      final List<Future<Void>> futures = messagesToSend.entrySet().stream().map(entry -> {
+        final MessageToSendKey key = entry.getKey();
+        final Set<String> value = entry.getValue();
+        final Promise<Void> promise = Promise.promise();
+        final IExplorerPluginClient client = IExplorerPluginClient.withBus(vertx, key.app, key.type);
+        client.reindex(new ExplorerReindexResourcesRequest(value))
+            .onComplete(e -> {
+              log.info("[DebouncedIngestionErrorReplayer@sendMessages] Done reindexing " + key);
+              promise.complete();
+            });
+        return promise.future();
+      }).collect(Collectors.toList());
+      messagesToSend.clear();
+      completion = CompositeFuture.join((List)futures).mapEmpty();
+    }
+    taskId = null;
+    return completion;
+  }
+
+  /**
+   * @return The number of messages to be send
+   */
+  public long getSize() {
+    return messagesToSend.values().stream()
+        .mapToLong(Set::size)
+        .sum();
+  }
+
+  private static class MessageToSendKey {
+    private final String app;
+    private final String type;
+
+    private MessageToSendKey(String app, String type) {
+      this.app = app;
+      this.type = type;
+    }
+
+    @Override
+    public boolean equals(Object o) {
+      if (this == o) return true;
+      if (o == null || getClass() != o.getClass()) return false;
+      MessageToSendKey that = (MessageToSendKey) o;
+      return Objects.equals(app, that.app) && Objects.equals(type, that.type);
+    }
+
+    @Override
+    public int hashCode() {
+      return Objects.hash(app, type);
+    }
+
+    @Override
+    public String toString() {
+      return "MessageToSendKey{" +
+          "app='" + app + '\'' +
+          ", type='" + type + '\'' +
+          '}';
+    }
+  }
+}

--- a/backend/src/main/java/com/opendigitaleducation/explorer/ingest/impl/MetricsUpdaterPermanentIngestionErrorHandler.java
+++ b/backend/src/main/java/com/opendigitaleducation/explorer/ingest/impl/MetricsUpdaterPermanentIngestionErrorHandler.java
@@ -1,0 +1,27 @@
+package com.opendigitaleducation.explorer.ingest.impl;
+
+import com.opendigitaleducation.explorer.ingest.ExplorerMessageForIngest;
+import com.opendigitaleducation.explorer.ingest.IngestJobMetricsRecorder;
+import com.opendigitaleducation.explorer.ingest.PermanentIngestionErrorHandler;
+import io.vertx.core.Future;
+
+import java.util.List;
+
+/**
+ * Update the metrics count of failed messages.
+ */
+public class MetricsUpdaterPermanentIngestionErrorHandler implements PermanentIngestionErrorHandler {
+  private final IngestJobMetricsRecorder ingestJobMetricsRecorder;
+
+  public MetricsUpdaterPermanentIngestionErrorHandler(final IngestJobMetricsRecorder ingestJobMetricsRecorder) {
+    this.ingestJobMetricsRecorder = ingestJobMetricsRecorder;
+  }
+
+  @Override
+  public Future<Void> handleDeletedMessages(final List<ExplorerMessageForIngest> permanentlyDeletedMessages) {
+    if(!permanentlyDeletedMessages.isEmpty()) {
+      this.ingestJobMetricsRecorder.onMessagesAttempedTooManyTimes(permanentlyDeletedMessages.size());
+    }
+    return Future.succeededFuture();
+  }
+}

--- a/backend/src/test/java/com/opendigitaleducation/explorer/ingest/impl/DebouncedIngestionErrorReplayerTest.java
+++ b/backend/src/test/java/com/opendigitaleducation/explorer/ingest/impl/DebouncedIngestionErrorReplayerTest.java
@@ -1,0 +1,164 @@
+package com.opendigitaleducation.explorer.ingest.impl;
+
+
+import com.opendigitaleducation.explorer.ingest.ExplorerMessageForIngest;
+import io.vertx.core.Vertx;
+import io.vertx.core.json.JsonObject;
+import io.vertx.ext.unit.Async;
+import io.vertx.ext.unit.TestContext;
+import io.vertx.ext.unit.junit.VertxUnitRunner;
+import org.entcore.common.explorer.ExplorerMessage;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+
+import java.util.ArrayList;
+import java.util.List;
+
+import static java.util.Collections.singletonList;
+
+@RunWith(VertxUnitRunner.class)
+public class DebouncedIngestionErrorReplayerTest {
+
+  /**
+   *  <h1>GOAL</h1>
+   *  <p>
+   *    Ensure that messages are correctly sent after the debounce delay period when no failed messages are reported.
+   *  </p>
+   * @param context Context
+   */
+  @Test
+  public void testDebounceDelayIsRespectedWhenNoMessageInserted(final TestContext context) {
+    final Async async = context.async();
+    final Vertx vertx = Vertx.vertx();
+    final DebouncedIngestionErrorReplayer replayer = new DebouncedIngestionErrorReplayer(vertx, 2000L, -1);
+    replayer.handleDeletedMessages(singletonList(
+        new ExplorerMessageForIngest(ExplorerMessage.ExplorerAction.Audience.name(), "idQueue", "myId", message("app", "type"))
+    ));
+    context.assertEquals(1L, replayer.getSize(), "There should be one pending resource to send");
+    vertx.setTimer(1000L, e -> context.assertEquals(1L, replayer.getSize(), "There should still be only one pending resource to send"));
+    vertx.setTimer(2100L, e -> {
+      context.assertEquals(0L, replayer.getSize(), "There should be no pending resources to send");
+      async.complete();
+    });
+  }
+
+  /**
+   *  <h1>GOAL</h1>
+   *  <p>
+   *    Ensure that messages are correctly sent after the debounce delay period when no failed messages are reported.
+   *  </p>
+   * @param context Context
+   */
+  @Test
+  public void testDebounceDelayIsNotRespectedWhenTooMuchMessagesArePending(final TestContext context) {
+    final Vertx vertx = Vertx.vertx();
+    final DebouncedIngestionErrorReplayer replayer = new DebouncedIngestionErrorReplayer(vertx, 20000L, 3);
+    replayer.handleDeletedMessages(singletonList(
+        new ExplorerMessageForIngest(ExplorerMessage.ExplorerAction.Audience.name(), "idQueue", "myId", message("app", "type"))
+    ));
+    context.assertEquals(1L, replayer.getSize(), "There should be one pending resource to send");
+    replayer.handleDeletedMessages(singletonList(
+        new ExplorerMessageForIngest(ExplorerMessage.ExplorerAction.Audience.name(), "idQueue2", "myId2", message("app", "type"))
+    ));
+    context.assertEquals(2L, replayer.getSize(), "There should be 2 pending resources to send because we haven't reached max length");
+    replayer.handleDeletedMessages(singletonList(
+        new ExplorerMessageForIngest(ExplorerMessage.ExplorerAction.Audience.name(), "idQueue2", "myId3", message("app", "type"))
+    ));
+    context.assertEquals(0L, replayer.getSize(), "There should be no pending resources to send because we have reached max length");
+  }
+  /**
+   *  <h1>GOAL</h1>
+   *  <p>
+   *    Ensure that messages of all apps are correctly sent.
+   *  </p>
+   *  <ol>
+   *    <li>Create 2 messages for app A</li>
+   *    <li>Create 1 message for app B with the id of one of the message of app A</li>
+   *    <li>Check that 3 messages are to be sent</li>
+   *  </ol>
+   * @param context Context
+   */
+  @Test
+  public void testSplitResourcesByAppAndType(final TestContext context) {
+    final Vertx vertx = Vertx.vertx();
+    final DebouncedIngestionErrorReplayer replayer = new DebouncedIngestionErrorReplayer(vertx, 100L, -1);
+    final List<ExplorerMessageForIngest> messages = new ArrayList<>();
+    messages.add(new ExplorerMessageForIngest(ExplorerMessage.ExplorerAction.Audience.name(), "idQueue", "myId", message("app", "type")));
+    messages.add(new ExplorerMessageForIngest(ExplorerMessage.ExplorerAction.Audience.name(), "idQueue", "myId2", message("app", "type")));
+    messages.add(new ExplorerMessageForIngest(ExplorerMessage.ExplorerAction.Audience.name(), "idQueue", "myId", message("app2", "type")));
+    replayer.handleDeletedMessages(messages);
+    context.assertEquals(3L, replayer.getSize(), "Should have all three items and not only 2 because the two that share the same id have different apps");
+  }
+
+  /**
+   *  <h1>GOAL</h1>
+   *  <p>
+   *    Ensure that messages are correctly sent after the debounce delay period when it has been reset after
+   *    a new failed message has been reported.
+   *  </p>
+   * @param context Context
+   */
+  @Test
+  public void testDebounceDelayIsRespectedWhenMessageInserted(final TestContext context) {
+    final Async async = context.async();
+    final Vertx vertx = Vertx.vertx();
+    final DebouncedIngestionErrorReplayer replayer = new DebouncedIngestionErrorReplayer(vertx, 2000L, -1);
+    replayer.handleDeletedMessages(singletonList(
+        new ExplorerMessageForIngest(ExplorerMessage.ExplorerAction.Audience.name(), "idQueue", "myId", message("app", "type"))
+    ));
+    context.assertEquals(1L, replayer.getSize(), "There should be one pending resource to send");
+    vertx.setTimer(1000L, e -> replayer.handleDeletedMessages(singletonList(
+        new ExplorerMessageForIngest(ExplorerMessage.ExplorerAction.Audience.name(), "idQueue2", "myId2", message("app", "type"))
+    )));
+    vertx.setTimer(2100L, e -> {
+      context.assertEquals(2L, replayer.getSize(), "Both messages should still be in the queue. It means that the debounce delay was not reset");
+    });
+    vertx.setTimer(3100L, e -> {
+      context.assertEquals(0L, replayer.getSize(), "The queue should be empty after the second debounce delay.");
+      async.complete();
+    });
+  }
+
+
+  /**
+   *  <h1>GOAL</h1>
+   *  <p>
+   *    Ensure that if multiple failing messages for the same resource won't trigger a reset of the sending delay
+   *  </p>
+   *  <h1>Steps</h1>
+   *  <ol>
+   *    <li>add a message for a resource at t0</li>
+   *    <li>wait for a short amount of time dt</li>
+   *    <li>add a new message</li>
+   *    <li>ensure that the length of the queue hasn't changed</li>
+   *    <li>check at t0 + debounceDelay that all messages have been sent</li>
+   *  </ol>
+   * @param context Context
+   */
+  @Test
+  public void testDoNotResetDelayWhenAMessageConcerningTheSameResourceIsAdded(final TestContext context) {
+    final Async async = context.async();
+    final Vertx vertx = Vertx.vertx();
+    final DebouncedIngestionErrorReplayer replayer = new DebouncedIngestionErrorReplayer(vertx, 1000L, -1);
+    replayer.handleDeletedMessages(singletonList(
+        new ExplorerMessageForIngest(ExplorerMessage.ExplorerAction.Audience.name(), "idQueue", "myId", message("app", "type"))
+    ));
+    context.assertEquals(1L, replayer.getSize(), "There should be one pending resource to send");
+    vertx.setTimer(500L, e -> {
+      replayer.handleDeletedMessages(singletonList(
+          new ExplorerMessageForIngest(ExplorerMessage.ExplorerAction.Audience.name(), "idQueue2", "myId", message("app", "type"))
+      ));
+      context.assertEquals(1L, replayer.getSize(), "There should still be only one pending resource to send because the added message reports to the same id");
+    });
+    vertx.setTimer(1100L, e -> {
+      context.assertEquals(0L, replayer.getSize(), "There should be no pending resources to send");
+      async.complete();
+    });
+  }
+
+  public static JsonObject message(final String app, final String type) {
+    return new JsonObject()
+        .put("application", app)
+        .put("resourceType", type);
+  }
+}


### PR DESCRIPTION
# Description

À l’heure actuelle, lorsque le job d’ingestion ne parvient pas à ingérer un message plus de n fois de suite (n étant configurable), ledit message est perdu.

Afin de tenter de préserver la cohérence de données entre l'app source et l'EUR, cette PR vise à donner la possibilité à l'EUR d'automatiquement  réindexer complètement la ressource concernée par les messages perdus.

Exemples :

Un message de création ou de mise à jour d’un blog est perdu → réindexer le blog en question

Un message de CRUD d’un post est perdu → réindexer le blog contenant le post
>

## Type of change

Please check options that are relevant.

- [ ] Chore (PATCH)
- [ ] Doc (PATCH)
- [ ] Bug fix (PATCH)
- [x] New feature (MINOR)
- [ ] Breaking change (MAJOR)

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings
