### PR TITLE
[EDIFICE] #WB2-1330, improve performance and reliability

### DIFF
--- a/backend/deployment/explorer/conf.json.template
+++ b/backend/deployment/explorer/conf.json.template
@@ -20,6 +20,7 @@
             "index": "explorer-index"
         },
         "ingest":{
+            "retry-read-ms": 1000,
             "consumer-block-ms": 0,
             "max-attempt": 10,
             "batch-size": 100,

--- a/backend/src/main/java/com/opendigitaleducation/explorer/folders/ResourceExplorerDbSql.java
+++ b/backend/src/main/java/com/opendigitaleducation/explorer/folders/ResourceExplorerDbSql.java
@@ -175,7 +175,7 @@ public class ResourceExplorerDbSql {
         final String query = String.format(queryTpl.toString(), insertPlaceholder);
         return client.preparedQuery(query, tuple).map(rows->{
             final Map<Integer, ResouceSql> results = new HashMap<>();
-            final List<ResouceSql> models = new ArrayList<>();
+            final Set<ResouceSql> models = new HashSet<>();
             for(final Row row : rows){
                 models.add(mapRowToModel(row, model -> {
                     // set if not exists -> ensure uniqueness
@@ -184,7 +184,7 @@ public class ResourceExplorerDbSql {
                     return results.get(model.id);
                 }));
             }
-            return models;
+            return new ArrayList<>(models);
         });
     }
 
@@ -381,7 +381,7 @@ public class ResourceExplorerDbSql {
         final String query = String.format(queryTpl.toString(), insertPlaceholder);
         return client.preparedQuery(query, tuple).map(rows->{
             final Map<Integer, ResouceSql> results = new HashMap<>();
-            final List<ResouceSql> models = new ArrayList<>();
+            final Set<ResouceSql> models = new HashSet<>();
             for(final Row row : rows){
                 models.add(mapRowToModel(row, model -> {
                     // set if not exists -> ensure uniqueness
@@ -390,7 +390,7 @@ public class ResourceExplorerDbSql {
                     return results.get(model.id);
                 }));
             }
-            return models;
+            return new ArrayList<>(models);
         });
     }
 

--- a/backend/src/main/java/com/opendigitaleducation/explorer/ingest/MessageReader.java
+++ b/backend/src/main/java/com/opendigitaleducation/explorer/ingest/MessageReader.java
@@ -19,15 +19,15 @@ public interface MessageReader {
         ExplorerPluginFactory.init(vertx, config);
         if(config.getString("stream", "redis").equalsIgnoreCase("redis")){
             final RedisClient redis = RedisClient.create(vertx, ExplorerPluginFactory.getRedisConfig());
-            return redis(redis, ingestConfig);
+            return redis(vertx, redis, ingestConfig);
         }else{
             final IPostgresClient postgres = IPostgresClient.create(vertx, ExplorerPluginFactory.getPostgresConfig(), true, false);
             return postgres(postgres, ingestConfig);
         }
     }
 
-    static MessageReader redis(final RedisClient client, final JsonObject config) {
-        return new MessageReaderRedis(client, config);
+    static MessageReader redis(final Vertx vertx, final RedisClient client, final JsonObject config) {
+        return new MessageReaderRedis(vertx, client, config);
     }
 
     static MessageReader postgres(final IPostgresClient client, final JsonObject config) {

--- a/backend/src/main/java/com/opendigitaleducation/explorer/ingest/MessageReaderRedis.java
+++ b/backend/src/main/java/com/opendigitaleducation/explorer/ingest/MessageReaderRedis.java
@@ -1,9 +1,6 @@
 package com.opendigitaleducation.explorer.ingest;
 
-import io.vertx.core.CompositeFuture;
-import io.vertx.core.Future;
-import io.vertx.core.Handler;
-import io.vertx.core.Promise;
+import io.vertx.core.*;
 import io.vertx.core.json.JsonArray;
 import io.vertx.core.json.JsonObject;
 import io.vertx.core.logging.Logger;
@@ -17,13 +14,16 @@ import java.util.function.Function;
 public class MessageReaderRedis implements MessageReader {
     static final Logger log = LoggerFactory.getLogger(MessageReaderRedis.class);
     static final Integer DEFAULT_BLOCK_MS = 0;//infinity
+    static final Integer DEFAULT_RETRY_READ_MS = 1000;//infinity
     static final String DEFAULT_CONSUMER_NAME = "message_reader";
     static final String DEFAULT_STREAM_FAIL = "_fail";
     static final String DEFAULT_CONSUMER_GROUP = "message_reader_group";
+    private final Vertx vertx;
     private final String consumerName;
     private final String consumerGroup;
     private final String streamFailSuffix;
     private final Integer consumerBlockMs;
+    private final Integer retryReadMs;
     private final Future<Void> onReady;
     private final RedisClient redisClient;
     private final List<String> streams = new ArrayList<>();
@@ -31,10 +31,13 @@ public class MessageReaderRedis implements MessageReader {
     private final JsonObject metrics = new JsonObject();
     private int pendingNotifications = 0;
     private boolean listening = false;
+    private Long retryTimer;
     private MessageReaderStatus status = MessageReaderStatus.Running;
 
-    public MessageReaderRedis(final RedisClient redisClient, final JsonObject config) {
+    public MessageReaderRedis(final Vertx vertx, final RedisClient redisClient, final JsonObject config) {
+        this.vertx = vertx;
         this.redisClient = redisClient;
+        this.retryReadMs = config.getInteger("retry-read-ms", DEFAULT_RETRY_READ_MS);
         this.consumerBlockMs = config.getInteger("consumer-block-ms", DEFAULT_BLOCK_MS);
         this.streamFailSuffix = config.getString("stream-fail-suffix", DEFAULT_STREAM_FAIL);
         this.consumerName = config.getString("consumer-name", DEFAULT_CONSUMER_NAME);
@@ -83,26 +86,41 @@ public class MessageReaderRedis implements MessageReader {
             //only new messages
             final String startFrom = ">";
             redisClient.xreadGroup(consumerGroup, consumerName, streams, true, Optional.of(1), Optional.of(consumerBlockMs), Optional.of(startFrom),true).onComplete(res -> {
-                if(res.failed()){
-                    log.error("Could not read xstream ",res.cause());
-                    return;
+                try {
+                    if (res.failed()) {
+                        log.error("Could not read xstream ", res.cause());
+                        return;
+                    }
+                    this.listening = false;
+                    if (res.result().size() > 0) {
+                        this.pendingNotifications++;
+                    }
+                    //do not notify each time
+                    if (isStopped()) {
+                        metrics.put("last_listen_skip_at", new Date().getTime());
+                        metrics.put("listen_skip_count", metrics.getInteger("listen_skip_count", 0) + 1);
+                    } else {
+                        metrics.put("last_listen_at", new Date().getTime());
+                        metrics.put("listen_count", metrics.getInteger("listen_count", 0) + 1);
+                    }
+                    //call listeners (avoid concurrent modification
+                    notifyListeners();
+                } finally {
+                    if(res.failed()){
+                        // if redis is down retry later
+                        //TODO add circuit breaker + exponential delay inside RedisClient?
+                        if(this.retryTimer != null){
+                            vertx.cancelTimer(this.retryTimer);
+                        }
+                        this.retryTimer = vertx.setTimer(this.retryReadMs, (Long time)->{
+                            //if paused on notify => stop listening => while rerun on resume
+                            scheduleXread();
+                        });
+                    }else{
+                        //if paused on notify => stop listening => while rerun on resume
+                        scheduleXread();
+                    }
                 }
-                this.listening = false;
-                if (res.result().size() > 0) {
-                    this.pendingNotifications++;
-                }
-                //do not notify each time
-                if (isStopped()) {
-                    metrics.put("last_listen_skip_at", new Date().getTime());
-                    metrics.put("listen_skip_count", metrics.getInteger("listen_skip_count", 0) + 1);
-                } else {
-                    metrics.put("last_listen_at", new Date().getTime());
-                    metrics.put("listen_count", metrics.getInteger("listen_count", 0) + 1);
-                }
-                //call listeners (avoid concurrent modification
-                notifyListeners();
-                //if paused on notify => stop listening => while rerun on resume
-                scheduleXread();
             });
         });
     }
@@ -125,6 +143,9 @@ public class MessageReaderRedis implements MessageReader {
     @Override
     public void stop() {
         status = MessageReaderStatus.Stopped;
+        if(this.retryTimer != null){
+            vertx.cancelTimer(this.retryTimer);
+        }
     }
 
     @Override
@@ -144,6 +165,7 @@ public class MessageReaderRedis implements MessageReader {
                     promise.complete(res.result());
                 } else {
                     log.error(String.format("Could not xread (%s,%s) from streams: %s | index=%s", consumerGroup, consumerName, stream, startAt), res.cause());
+                    promise.fail(res.cause());
                 }
             });
             return promise.future();
@@ -161,7 +183,7 @@ public class MessageReaderRedis implements MessageReader {
                 result.addAll(r);
                 final int newMaxBatchSize = maxBatchSize - result.size();
                 if (newMaxBatchSize > 0) {
-                    return fetchOneStream(nextStream, maxBatchSize, true);
+                    return fetchOneStream(nextStream, newMaxBatchSize, true);
                 } else {
                     return Future.succeededFuture(new ArrayList<>());
                 }
@@ -171,7 +193,7 @@ public class MessageReaderRedis implements MessageReader {
                 result.addAll(r);
                 final int newMaxBatchSize = maxBatchSize - result.size();
                 if (newMaxBatchSize > 0) {
-                    return fetchOneStream(nextStream, maxBatchSize, false);
+                    return fetchOneStream(nextStream, newMaxBatchSize, false);
                 } else {
                     return Future.succeededFuture(new ArrayList<>());
                 }
@@ -226,6 +248,7 @@ public class MessageReaderRedis implements MessageReader {
 
     @Override
     public Future<Void> updateStatus(final IngestJob.IngestJobResult ingestResult, final int maxAttempt) {
+        final Set<String> processed = new HashSet<>();
         //prepare
         final List<Future> transactions = new ArrayList<>();
         //on succeed => ACK + DEL (DEL only if ACK succeed)
@@ -236,38 +259,43 @@ public class MessageReaderRedis implements MessageReader {
         // them pass
         toAck.addAll(ingestResult.skipped);
         for (final ExplorerMessageForIngest mess : toAck) {
-            if(mess.getIdQueue().isPresent()) {
+            if(mess.getIdQueue().isPresent() && !processed.contains(mess.getIdQueue().get())) {
                 final String idQueue = mess.getIdQueue().get();
                 final String stream = mess.getMetadata().getString(RedisClient.NAME_STREAM);
-                //final RedisTransaction batch = redisClient.transaction();
-                redisClient.xAck(stream, consumerGroup, idQueue);
-                redisClient.xDel(stream, idQueue);
-                //transactions.add(batch.commit());
+                processed.add(idQueue);
+                // ACK message then delete it
+                transactions.add(redisClient.xAck(stream, consumerGroup, idQueue).compose(onAck -> {
+                    return redisClient.xDel(stream, idQueue);
+                }));
             }
         }
         //on failed => ADD + ACK + DEL (ACK only if ADD suceed and DEL only if ACK succeed)
         for (final ExplorerMessageForIngest mess : ingestResult.failed) {
-            if(mess.getIdQueue().isPresent()) {
+            if(mess.getIdQueue().isPresent() && !processed.contains(mess.getIdQueue().get())) {
                 final String idQueue = mess.getIdQueue().get();
                 final String stream = mess.getMetadata().getString(RedisClient.NAME_STREAM, "");
                 final int attemptCount = mess.getAttemptCount();
+                processed.add(idQueue);
                 if(attemptCount > maxAttempt) {
                     log.warn("A message has been dropped because it was attempted " + attemptCount + " : " + mess);
+                    transactions.add(redisClient.xAck(stream, consumerGroup, idQueue).compose(onAck -> {
+                        return redisClient.xDel(stream, idQueue);
+                    }));
                 } else {
                     final JsonObject json = toJson(mess).put("attempt_count", attemptCount + 1)
                             .put("attempted_at", new Date().getTime())
                             .put("error", mess.getError());
-                    //final RedisTransaction batch = redisClient.transaction();
                     //if already failed => do not add suffix to stream name
-                    if (stream.contains(streamFailSuffix)) {
-                        redisClient.xAdd(stream, json);
-                    } else {
-                        redisClient.xAdd(stream + streamFailSuffix, json);
-                    }
+                    final String targetStream = stream.contains(streamFailSuffix)? stream : stream + streamFailSuffix;
+                    // add message to failed stream
+                    transactions.add(redisClient.xAdd(targetStream, json).compose(onAdd->{
+                        // ack message from old stream
+                        return redisClient.xAck(stream, consumerGroup, idQueue).compose(onAck -> {
+                            // del message from old stream
+                            return redisClient.xDel(stream, idQueue);
+                        });
+                    }));
                 }
-                redisClient.xAck(stream, consumerGroup, idQueue);
-                redisClient.xDel(stream, idQueue);
-                //transactions.add(batch.commit());
             }
         }
         //execute batch

--- a/backend/src/test/java/com/opendigitaleducation/explorer/DiscreteFailureTest.java
+++ b/backend/src/test/java/com/opendigitaleducation/explorer/DiscreteFailureTest.java
@@ -121,7 +121,7 @@ public class DiscreteFailureTest {
         pluginClient = IExplorerPluginClient.withBus(test.vertx(), FakeMongoPlugin.FAKE_APPLICATION, FakeMongoPlugin.FAKE_TYPE);
         //flush redis
         redisClient.getClient().flushall(new ArrayList<>(), e -> {
-            final MessageReader reader = MessageReader.redis(redisClient, redisConfig);
+            final MessageReader reader = MessageReader.redis(test.vertx(), redisClient, redisConfig);
             job = IngestJob.createForTest(test.vertx(), elasticClientManager, postgresClient, jobConf, reader);
             //start job to create streams
             job.start().compose(ee -> job.stop())

--- a/backend/src/test/java/com/opendigitaleducation/explorer/ExplorerControllerTest.java
+++ b/backend/src/test/java/com/opendigitaleducation/explorer/ExplorerControllerTest.java
@@ -99,7 +99,7 @@ public class ExplorerControllerTest {
         //flush redis
         final Async async = context.async();
         redisClient.getClient().flushall(new ArrayList<>(), e -> {
-            final MessageReader reader = MessageReader.redis(redisClient, new JsonObject());
+            final MessageReader reader = MessageReader.redis(test.vertx(), redisClient, new JsonObject());
             job = IngestJob.createForTest(test.vertx(), esClientManager, postgresClient, jobConf, reader);
             //start job to create streams
             job.start().compose(ee -> {

--- a/backend/src/test/java/com/opendigitaleducation/explorer/FolderServiceTest.java
+++ b/backend/src/test/java/com/opendigitaleducation/explorer/FolderServiceTest.java
@@ -75,7 +75,7 @@ public class FolderServiceTest {
         createMapping(elasticClientManager, context, index).onComplete(r -> promiseMapping.complete());
         createScript(test.vertx(), elasticClientManager).onComplete(r -> promiseScript.complete());
         final JsonObject jobConf = new JsonObject().put("opensearch-options", new JsonObject().put("wait-for", true));
-        final MessageReader reader = MessageReader.redis(redisClient, new JsonObject());
+        final MessageReader reader = MessageReader.redis(test.vertx(), redisClient, new JsonObject());
         job = IngestJob.createForTest(test.vertx(), elasticClientManager, postgresClient, jobConf, reader);
     }
 

--- a/backend/src/test/java/com/opendigitaleducation/explorer/FolderTrashTest.java
+++ b/backend/src/test/java/com/opendigitaleducation/explorer/FolderTrashTest.java
@@ -85,7 +85,7 @@ public class FolderTrashTest {
         createMapping(elasticClientManager, context, index).onComplete(r -> promiseMapping.complete());
         createScript(test.vertx(), elasticClientManager).onComplete(r -> promiseScript.complete());
         final JsonObject jobConfig = new JsonObject().put("opensearch-options", new JsonObject().put("wait-for", true));
-        final MessageReader reader = MessageReader.redis(redisClient, new JsonObject());
+        final MessageReader reader = MessageReader.redis(test.vertx(), redisClient, new JsonObject());
         job = IngestJob.createForTest(test.vertx(), elasticClientManager, postgresClient, jobConfig, reader);
         ExplorerConfig.getInstance().setSkipIndexOfTrashedFolders(true);
     }

--- a/backend/src/test/java/com/opendigitaleducation/explorer/FullExplorerStackTest.java
+++ b/backend/src/test/java/com/opendigitaleducation/explorer/FullExplorerStackTest.java
@@ -137,7 +137,7 @@ public class FullExplorerStackTest {
         final JsonObject rights = new JsonObject();
         //flush redis
         redisClient.getClient().flushall(new ArrayList<>(), e -> {
-            final MessageReader reader = MessageReader.redis(redisClient, redisConfig);
+            final MessageReader reader = MessageReader.redis(test.vertx(), redisClient, redisConfig);
             job = IngestJob.create(test.vertx(), elasticClientManager, postgresClient, jobConf, reader);
             //start job to create streams
             job.start().compose(ee -> job.stop())

--- a/backend/src/test/java/com/opendigitaleducation/explorer/IngestJobPGFailingTest.java
+++ b/backend/src/test/java/com/opendigitaleducation/explorer/IngestJobPGFailingTest.java
@@ -118,7 +118,7 @@ public class IngestJobPGFailingTest {
         pluginClient = IExplorerPluginClient.withBus(test.vertx(), FakeMongoPlugin.FAKE_APPLICATION, FakeMongoPlugin.FAKE_TYPE);
         //flush redis
         redisClient.getClient().flushall(new ArrayList<>(), e -> {
-            final MessageReader reader = MessageReader.redis(redisClient, redisConfig);
+            final MessageReader reader = MessageReader.redis(test.vertx(), redisClient, redisConfig);
             job = IngestJob.createForTest(test.vertx(), elasticClientManager, postgresClient, jobConf, reader);
             //start job to create streams
             job.start().compose(ee -> job.stop())

--- a/backend/src/test/java/com/opendigitaleducation/explorer/IngestJobRedisDuplicateTest.java
+++ b/backend/src/test/java/com/opendigitaleducation/explorer/IngestJobRedisDuplicateTest.java
@@ -85,7 +85,7 @@ public class IngestJobRedisDuplicateTest {
         final JsonObject postgresqlConfig = new JsonObject().put("host", pgContainer.getHost()).put("database", pgContainer.getDatabaseName()).put("user", pgContainer.getUsername()).put("password", pgContainer.getPassword()).put("port", pgContainer.getMappedPort(5432));
         postgresClient = new PostgresClient(test.vertx(), postgresqlConfig);
         final JsonObject jobConfig = new JsonObject().put("opensearch-options", new JsonObject().put("wait-for", true)).put("messageTransformers", new JsonArray().add(new JsonObject().put("id", "htmlAnalyse").put("minLength", 0)));
-        final MessageReader reader = MessageReader.redis(redisClient, new JsonObject());
+        final MessageReader reader = MessageReader.redis(test.vertx(), redisClient, new JsonObject());
         final IngestJobMetricsRecorder recorder = IngestJobMetricsRecorderFactory.getIngestJobMetricsRecorder();
         final MessageIngester inner = MessageIngester.elasticWithPgBackup(elasticClientManager, postgresClient, recorder, jobConfig);
         ingester = new FailingIngester(inner);

--- a/backend/src/test/java/com/opendigitaleducation/explorer/IngestJobStressTest.java
+++ b/backend/src/test/java/com/opendigitaleducation/explorer/IngestJobStressTest.java
@@ -117,7 +117,7 @@ public class IngestJobStressTest {
         pluginClient = IExplorerPluginClient.withBus(test.vertx(), FakeMongoPlugin.FAKE_APPLICATION, FakeMongoPlugin.FAKE_TYPE);
         //flush redis
         redisClient.getClient().flushall(new ArrayList<>(), e -> {
-            final MessageReader reader = MessageReader.redis(redisClient, redisConfig);
+            final MessageReader reader = MessageReader.redis(test.vertx(), redisClient, redisConfig);
             job = IngestJob.createForTest(test.vertx(), elasticClientManager, postgresClient, jobConf, reader);
             //start job to create streams
             job.start().compose(ee -> job.stop())

--- a/backend/src/test/java/com/opendigitaleducation/explorer/IngestJobTestRedis.java
+++ b/backend/src/test/java/com/opendigitaleducation/explorer/IngestJobTestRedis.java
@@ -82,7 +82,7 @@ public class IngestJobTestRedis extends IngestJobTest {
     @Override
     protected synchronized IngestJob getIngestJob() {
         if (job == null) {
-            final MessageReader reader = MessageReader.redis(getRedisClient(), new JsonObject());
+            final MessageReader reader = MessageReader.redis(test.vertx(), getRedisClient(), new JsonObject());
             final JsonObject jobConfig = new JsonObject().put("opensearch-options", new JsonObject().put("wait-for", true));
             job = IngestJob.createForTest(test.vertx(), elasticClientManager,getPostgresClient(), jobConfig, reader);
         }

--- a/backend/src/test/java/com/opendigitaleducation/explorer/ResourceMoveTest.java
+++ b/backend/src/test/java/com/opendigitaleducation/explorer/ResourceMoveTest.java
@@ -98,7 +98,7 @@ public class ResourceMoveTest {
         createMappingResource(elasticClientManager, context, indexResource).onComplete(r -> promiseMappingResource.complete());
         createScript(test.vertx(), elasticClientManager).onComplete(r -> promiseScript.complete());
         final JsonObject jobConfig = new JsonObject().put("opensearch-options", new JsonObject().put("wait-for", true));
-        final MessageReader reader = MessageReader.redis(redisClient, new JsonObject());
+        final MessageReader reader = MessageReader.redis(test.vertx(), redisClient, new JsonObject());
         job = IngestJob.createForTest(test.vertx(), elasticClientManager, postgresClient, jobConfig, reader);
         ExplorerConfig.getInstance().setSkipIndexOfTrashedFolders(true);
         plugin = FakePostgresPlugin.withRedisStream(test.vertx(), redisClient, postgresClient);

--- a/backend/src/test/java/com/opendigitaleducation/explorer/ResourceServiceTest.java
+++ b/backend/src/test/java/com/opendigitaleducation/explorer/ResourceServiceTest.java
@@ -82,7 +82,7 @@ public class ResourceServiceTest {
         final JsonObject postgresqlConfig = new JsonObject().put("host", pgContainer.getHost()).put("database", pgContainer.getDatabaseName()).put("user", pgContainer.getUsername()).put("password", pgContainer.getPassword()).put("port", pgContainer.getMappedPort(5432));
         final PostgresClient postgresClient = new PostgresClient(test.vertx(), postgresqlConfig);
         final JsonObject jobConfig = new JsonObject().put("opensearch-options", new JsonObject().put("wait-for", true));
-        final MessageReader reader = MessageReader.redis(redisClient, new JsonObject());
+        final MessageReader reader = MessageReader.redis(test.vertx(), redisClient, new JsonObject());
         job = IngestJob.createForTest(test.vertx(), elasticClientManager,postgresClient, jobConfig, reader);
         plugin = FakePostgresPlugin.withRedisStream(test.vertx(), redisClient, postgresClient);
         final ShareTableManager shareTableManager = new DefaultShareTableManager();

--- a/backend/src/test/java/com/opendigitaleducation/explorer/ResourceTrashTest.java
+++ b/backend/src/test/java/com/opendigitaleducation/explorer/ResourceTrashTest.java
@@ -96,7 +96,7 @@ public class ResourceTrashTest {
         createMappingResource(elasticClientManager, context, indexResource).onComplete(r -> promiseMappingResource.complete());
         createScript(test.vertx(), elasticClientManager).onComplete(r -> promiseScript.complete());
         final JsonObject jobConfig = new JsonObject().put("opensearch-options", new JsonObject().put("wait-for", true));
-        final MessageReader reader = MessageReader.redis(redisClient, new JsonObject());
+        final MessageReader reader = MessageReader.redis(test.vertx(), redisClient, new JsonObject());
         job = IngestJob.createForTest(test.vertx(), elasticClientManager, postgresClient, jobConfig, reader);
         ExplorerConfig.getInstance().setSkipIndexOfTrashedFolders(true);
         plugin = FakePostgresPlugin.withRedisStream(test.vertx(), redisClient, postgresClient);


### PR DESCRIPTION
# Description

Ce fix a pour but de corriger des soucis rencontrés en prod:
- perte de message malgré les dead letters
- soucis d'indexation infini qui ne se résoud pas malgré les rejeux
- job qui s'arrête définitivement
- disk full à cause des logs si trop d'erreur opensearch
- augmentation des tailles de lot automatique malgré un redis qui ne répond pas
- éviter un dépassement de la taille du lot pour ne pas surcharger opensearch
- meilleur gestion des acquittement des stream redis

Les correctifs suivants sont apportés:
- Remplacement d'ArrayList par des HashSet car si une ressource possèdait des centaines de dossiers , on pouvait se retrouver avec une taille de lot x100 (donc 100x1000) ce qui rendait l'indexation elastic search impossible sur les gros contenus malgré le shrink
- replanification du job même si l'itération précèdente a une erreur non intercepté
- logs des messages en erreur uniquement lorsqu'ils sont définitivement supprimé (lors des rejeu seul l'ID est loggué)
- augmentation automatique de la taille de lot seulement si le nombre de message avec succès est positif => si redis ne repond plus on se retrouvait avec 0 succès et 0 echec et une taille de batch qui augmente alors qu'il ne faudrait pas
- replanification du xread redis ultérieurement (via timer) dans le cas où redis serait down => sinon il s'arrêtait définitivement d'écouter les nouveaux messages
- prise en compte des différents files de priorité dans le calcul du nombre de message à lire depuis redis
- synchronisation des XDEL et XACK pour éviter qu'un XDEL ne se produisent si le XACK a échoué (du coup on se retrouve avec des files de consommateurs avec pour valeur nil)
- 1 seul mis à jour de status par idQueue (il peut arriver qu'en cas d'erreurs des messages soient dédoublonnées et que des mis à jour de status contradictoires ait lieu l'idée est d'éviter ça)

Les TU sont ok et des tests ont été sur une plateforme avec:
- des gros contenu / gros partages / nombreux dossiers rattachés
- le disk n'est pas saturé en cas de surcharge de opensearch
- la file continue d'être traité malgré des restart redis
- les messages ne sont plus dédoublonnées (ajout de log pour le constater)
- si redis et opensearch sont saturés il n'y a pas de surprises ni d'augmentation de la taille de la file, le shrink fait son travail et la file est traité même si c'est long

## Type of change

Please check options that are relevant.

- [ ] Chore (PATCH)
- [ ] Doc (PATCH)
- [ X] Bug fix (PATCH)
- [ ] New feature (MINOR)
- [ ] Breaking change (MAJOR)

> PATCH: refactor, internal or non-breaking change which fixes an issue
>
> MINOR: non-breaking change which adds functionality
>
> MAJOR: fix or feature that would cause existing functionality to not work as expected

## Checklist:

- [X ] My code follows the style guidelines of this project
- [X ] I have performed a self-review of my own code
- [ X] I have commented my code, particularly in hard-to-understand areas
- [X ] My changes generate no new warnings
